### PR TITLE
Fix @Substitution to use the correct target class

### DIFF
--- a/net/src/main/java/io/smallrye/common/net/Substitutions.java
+++ b/net/src/main/java/io/smallrye/common/net/Substitutions.java
@@ -16,8 +16,8 @@ import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
 final class Substitutions {
-    @TargetClass(className = "org.wildfly.common.net.GetHostInfoAction")
-    static final class Target_org_wildfly_common_net_GetHostInfoAction {
+    @TargetClass(className = "io.smallrye.common.net.GetHostInfoAction")
+    static final class Target_io_smallrye_common_net_GetHostInfoAction {
         @Substitute
         public String[] run() {
             // still allow host name to be overridden


### PR DESCRIPTION
Fixes the `@TargetClass` to point to `io.smallrye.common.net.GetHostInfoAction` instead of the unrelated one from wildfly-common project.

P.S: I have done zero testing of this - not even tried compiling it. I just used GitHub editor to raise this change as a PR.