### PR TITLE
Build with Jakarta 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,3 +171,29 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
         run: mvn -B verify --file pom.xml -Pcoverage javadoc:javadoc sonar:sonar -Dsonar.projectKey=smallrye_smallrye-common -Dsonar.login=$SONAR_TOKEN
+
+  jakarta:
+    needs: [build-linux]
+    runs-on: ubuntu-latest
+    name: jakarta
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: AdoptOpenJDK/install-jdk@v1
+        with:
+          version: 11
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Rename Jakarta
+        run: |
+          mvn gav:rename -s .mvn/plugin-settings.xml -DgroupId=io.smallrye -DartifactId=smallrye-parent -DnewGroupId=io.smallrye -DnewArtifactId=smallrye-jakarta-parent
+          mvn gav:rename -s .mvn/plugin-settings.xml -DartifactIdPattern=smallrye-common -DnewArtifactId=smallrye-common-jakarta
+          find . -type f -name '*.java' -exec sed -i'' -e 's/javax./jakarta./g' {} +
+          mvn verify

--- a/.mvn/plugin-settings.xml
+++ b/.mvn/plugin-settings.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <pluginGroups>
+        <pluginGroup>com.radcortez.maven</pluginGroup>
+    </pluginGroups>
+
+    <profiles>
+        <profile>
+            <id>plugin-snapshot-repository</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>central</id>
+                    <name>Central</name>
+                    <releases>
+                        <enabled>true</enabled>
+                        <checksumPolicy>warn</checksumPolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                        <checksumPolicy>fail</checksumPolicy>
+                    </snapshots>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+</settings>


### PR DESCRIPTION
Generates a build using Jakarta 9 dependencies by renaming the artifactId of the project and adding a `jakarta`name, replacing any `javax` to `jakarta` references in the source code and building new binaries from all the changes.

This allows creating a Jakarta 9 release without having to maintain two separate branches and keep the same version (only the artifatIds are different).

Example:

The SmallRye Common BOM GAV is `smallrye-common-bom` a new BOM for jakarta is generated as `smallrye-common-jakarta-bom`. The same rules apply to all other modules.