### PR TITLE
Generate the Jandex index for the annotation module.

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -31,6 +31,15 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jboss.jandex</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>coverage</id>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <properties>
         <version.graalvm>19.2.1</version.graalvm>
         <version.sundrio>0.80.0</version.sundrio>
+        <version.jandex-maven-plugin>1.2.2</version.jandex-maven-plugin>
 
         <!-- Sonar settings -->
         <sonar.projectName>SmallRye Common</sonar.projectName>
@@ -125,6 +126,23 @@
     </dependencyManagement>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.jboss.jandex</groupId>
+                    <artifactId>jandex-maven-plugin</artifactId>
+                    <version>${version.jandex-maven-plugin}</version>
+                    <executions>
+                        <execution>
+                            <id>make-index</id>
+                            <goals>
+                                <goal>jandex</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
It is required because it contains qualifiers and these qualifiers need to be in the index for Arc to find them.