### PR TITLE
Fix JavaDoc formatting issue

### DIFF
--- a/annotation/src/main/java/io/smallrye/common/annotation/CheckReturnValue.java
+++ b/annotation/src/main/java/io/smallrye/common/annotation/CheckReturnValue.java
@@ -2,15 +2,15 @@ package io.smallrye.common.annotation;
 
 import java.lang.annotation.*;
 
-@Retention(RetentionPolicy.RUNTIME)
-@Documented
-@Target(ElementType.METHOD)
 /**
  * Marker annotation for methods whose return values shall not be ignored under common API usage patterns.
  * <p>
  * Static analysis tools can leverage this annotation under JSR 305 semantics.
- *
+ * <p>
  * IntelliJ IDEA is known to consider {@code CheckReturnValue} annotations, no matter what the package.
  */
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Target(ElementType.METHOD)
 public @interface CheckReturnValue {
 }


### PR DESCRIPTION
IntelliJ at least cannnot "see" the docs on this element because they appear after annotations.