### PR TITLE
Finish remaining `module-info` descriptors

### DIFF
--- a/expression/pom.xml
+++ b/expression/pom.xml
@@ -36,19 +36,11 @@
         </dependency>
     </dependencies>
 
-    <!-- Until we merge https://github.com/smallrye/smallrye-common/pull/159/ -->
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>io.smallrye.common.expression</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
+              <groupId>io.github.dmlloyd.module-info</groupId>
+              <artifactId>module-info</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/expression/src/main/java/module-info.yml
+++ b/expression/src/main/java/module-info.yml
@@ -1,0 +1,6 @@
+name: io.smallrye.common.expression
+
+requires:
+  - module: io.smallrye.common.constraint
+  - module: io.smallrye.common.function
+  - module: org.jboss.logging

--- a/net/pom.xml
+++ b/net/pom.xml
@@ -44,19 +44,11 @@
         </dependency>
     </dependencies>
 
-    <!-- Until we merge https://github.com/smallrye/smallrye-common/pull/159/ -->
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>io.smallrye.common.net</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
+                <groupId>io.github.dmlloyd.module-info</groupId>
+                <artifactId>module-info</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/net/src/main/java/module-info.yml
+++ b/net/src/main/java/module-info.yml
@@ -1,0 +1,5 @@
+name: io.smallrye.common.net
+
+requires:
+  - module: io.smallrye.common.constraint
+  - module: org.jboss.logging

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <version.vertx>4.3.8</version.vertx>
         <version.maven>3.8.6</version.maven>
         <version.shrinkwrap>1.2.6</version.shrinkwrap>
+        <version.org.jboss.logging>3.5.0.Final</version.org.jboss.logging>
 
         <!-- Sonar settings -->
         <sonar.projectName>SmallRye Common</sonar.projectName>

--- a/version/pom.xml
+++ b/version/pom.xml
@@ -48,19 +48,11 @@
         </dependency>
     </dependencies>
 
-    <!-- Until we merge https://github.com/smallrye/smallrye-common/pull/159/ -->
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>io.smallrye.common.version</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
+                <groupId>io.github.dmlloyd.module-info</groupId>
+                <artifactId>module-info</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/version/src/main/java/module-info.yml
+++ b/version/src/main/java/module-info.yml
@@ -1,0 +1,5 @@
+name: io.smallrye.common.version
+
+requires:
+  - module: io.smallrye.common.constraint
+  - module: org.jboss.logging

--- a/vertx-context/pom.xml
+++ b/vertx-context/pom.xml
@@ -43,20 +43,12 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>io.github.dmlloyd.module-info</groupId>
+                <artifactId>module-info</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.jboss.jandex</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-            </plugin>
-            <!-- Until we merge https://github.com/smallrye/smallrye-common/pull/159/ -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>io.smallrye.common.vertx</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/vertx-context/src/main/java/module-info.yml
+++ b/vertx-context/src/main/java/module-info.yml
@@ -1,0 +1,6 @@
+name: io.smallrye.common.vertx
+
+requires:
+  - module: io.smallrye.common.constraint
+  - module: io.vertx.core
+  - module: org.jboss.logging


### PR DESCRIPTION
Fixes #158.

~~This is a draft until the JBoss Logging release trickles out to Maven Central.~~

JBoss Logging requires Java 11 as of version 3.5.0.Final; thus this PR now depends on #153.