### PR TITLE
The release archive of smallrye-common-annotation has been modified to exclude jandex.

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -34,10 +34,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jboss.jandex</groupId>
-        <artifactId>jandex-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>io.github.dmlloyd.module-info</groupId>
         <artifactId>module-info</artifactId>
       </plugin>


### PR DESCRIPTION
This change was implemented because if a jandex.idx, not rebuilt during the build process, is unintentionally included in the UberJar, it may prevent the application from functioning correctly.

It should be noted that within this project, the only archive released that includes jandex.idx is annotations.