### PR TITLE
Discontinue dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    groups:
-      maven-dependencies:
-        patterns:
-          - "*" # batch them all at once
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    groups:
-      ci-dependencies:
-        patterns:
-          - "*" # batch them all at once


### PR DESCRIPTION
It makes it harder to exclude certain versions and consider changes independently. This was an experiment; the experiment failed.