### PR TITLE
Release micros off of stable branch

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,5 @@
 name: SmallRye Common
+# for this project, always set next-version to the next *minor* unless it's on a stable branch!
 release:
   current-version: 2.3.0
-  next-version: 2.3.1-SNAPSHOT
+  next-version: 2.4.0-SNAPSHOT


### PR DESCRIPTION
We are ending up with PRs not being attached to the proper milestones when a minor is released.