### PR TITLE
Fix incomplete descriptor for `constraint` module

### DIFF
--- a/constraint/src/main/java/module-info.yml
+++ b/constraint/src/main/java/module-info.yml
@@ -1,0 +1,4 @@
+name: io.smallrye.common.constraint
+
+requires:
+  - module: org.jboss.logging


### PR DESCRIPTION
Fixes problem where logging messages cannot be loaded in module mode. The dependency for `jboss-logging` was missing.