### PR TITLE
Save StringConcat bytecode generation for one-time operation

### DIFF
--- a/ref/src/main/java/io/smallrye/common/ref/References.java
+++ b/ref/src/main/java/io/smallrye/common/ref/References.java
@@ -31,7 +31,16 @@ public final class References {
             if (isBuildTime()) {
                 // do nothing (class should be reinitialized)
             } else {
-                final PrivilegedAction<Void> action = () -> startThreadAction(1);
+                final PrivilegedAction<Void> action = new PrivilegedAction<>() {
+                    @Override
+                    public Void run() {
+                        final ReaperThread thr = new ReaperThread();
+                        thr.setName("Reference Reaper #1");
+                        thr.setDaemon(true);
+                        thr.start();
+                        return null;
+                    }
+                };
                 doPrivileged(action);
             }
         }
@@ -42,14 +51,6 @@ public final class References {
             } catch (Throwable ignored) {
                 return false;
             }
-        }
-
-        private static Void startThreadAction(int id) {
-            final ReaperThread thr = new ReaperThread();
-            thr.setName("Reference Reaper #" + id);
-            thr.setDaemon(true);
-            thr.start();
-            return null;
         }
 
         public void run() {


### PR DESCRIPTION
This has popup as a bytecode generation operation which can both save memory and CPU time at startup, see

![image](https://github.com/smallrye/smallrye-common/assets/13125299/2eeaf400-d65e-4489-ab3b-bc8fce435acc)

It both save the lambda generation and, most importantly, a useless string concatenation.
