### PR TITLE
Fix "quality" build job to use correct JDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: 'maven'
           cache-dependency-path: '**/pom.xml'
 


### PR DESCRIPTION
Otherwise JavaDoc checks fail after release.