### PR TITLE
Expression NO_$$ mode

### DIFF
--- a/expression/src/main/java/io/smallrye/common/expression/Expression.java
+++ b/expression/src/main/java/io/smallrye/common/expression/Expression.java
@@ -410,6 +410,9 @@ public final class Expression {
                             if (flags.contains(Flag.MINI_EXPRS)) {
                                 // TP 13
                                 list.add(new ExpressionNode(false, LiteralNode.DOLLAR, Node.NULL));
+                            } else if (flags.contains(Flag.NO_$$)) {
+                                list.add(LiteralNode.DOLLAR);
+                                itr.prev();
                             } else {
                                 // just resolve $$ to $
                                 // TP 14
@@ -493,10 +496,12 @@ public final class Expression {
                                         Node.NULL));
                                 start = itr.getNextIdx();
                                 continue;
-                            } else if (flags.contains(Flag.LENIENT_SYNTAX)) {
+                            } else if (flags.contains(Flag.LENIENT_SYNTAX) || flags.contains(Flag.NO_$$)) {
                                 // TP 26
                                 // just treat it as literal
-                                start = itr.getPrevIdx() - 1; // we can use 1 here because unicode '$' is one char in size
+                                list.add(LiteralNode.DOLLAR);
+                                itr.prev();
+                                start = itr.getNextIdx();
                                 continue;
                             } else {
                                 // TP 27
@@ -592,6 +597,10 @@ public final class Expression {
                                 case 'f': {
                                     // TP 39
                                     node = LiteralNode.FORM_FEED;
+                                    break;
+                                }
+                                case '$': {
+                                    node = LiteralNode.DOLLAR;
                                     break;
                                 }
                                 case '\\': {
@@ -694,6 +703,11 @@ public final class Expression {
          * character.
          */
         ESCAPES,
+        /**
+         * Escaping <code>$</code> with <code>$$</code> or <code>/$</code> only applies when <code>{</code> follows
+         * the initial escaped <code>$</code>.
+         */
+        NO_$$,
         /**
          * Treat expressions containing a double-colon delimiter as special, encoding the entire content into the key.
          */

--- a/expression/src/test/java/io/smallrye/common/expression/ExpressionTestCase.java
+++ b/expression/src/test/java/io/smallrye/common/expression/ExpressionTestCase.java
@@ -674,8 +674,8 @@ public class ExpressionTestCase {
         }), "SRCOM01000: Invalid expression syntax at position 0");
         assertThrows(IllegalArgumentException.class, () -> Expression.compile("a\\", ESCAPES).evaluate((c, b) -> {
         }), "SRCOM01000: Invalid expression syntax at position 0");
-        assertThrows(IllegalArgumentException.class, () -> Expression.compile("\\${foo}", ESCAPES).evaluate((c, b) -> {
-        }), "SRCOM01000: Invalid expression syntax at position 0");
+        assertEquals("${foo}", Expression.compile("\\${foo}", ESCAPES).evaluate((c, b) -> {
+        }));
 
         // NO_SMART_BRACES
         assertEquals("", Expression.compile("${foo}", NO_SMART_BRACES).evaluate((c, b) -> {
@@ -691,6 +691,122 @@ public class ExpressionTestCase {
         }));
         assertEquals("{d}", Expression.compile("${foo:{d}}", NO_SMART_BRACES).evaluate((c, b) -> {
             b.append(c.getExpandedDefault());
+        }));
+    }
+
+    @Test
+    void no$$() {
+        assertThrows(IllegalArgumentException.class, () -> Expression.compile("$", NO_$$).evaluate((c, b) -> {
+        }));
+        assertThrows(IllegalArgumentException.class, () -> Expression.compile("$$", NO_$$).evaluate((c, b) -> {
+        }));
+        assertThrows(IllegalArgumentException.class, () -> Expression.compile("\\$", NO_$$).evaluate((c, b) -> {
+        }));
+        assertThrows(IllegalArgumentException.class, () -> Expression.compile("\\$$", NO_$$).evaluate((c, b) -> {
+        }));
+        assertEquals("$$foo", Expression.compile("$$foo", NO_$$).evaluate((c, b) -> {
+        }));
+        assertThrows(IllegalArgumentException.class, () -> Expression.compile("foo$$", NO_$$).evaluate((c, b) -> {
+        }));
+        assertEquals("foo$$bar", Expression.compile("foo$$bar", NO_$$).evaluate((c, b) -> {
+        }));
+        assertEquals("$", Expression.compile("$${foo}", NO_$$).evaluate((c, b) -> {
+            assertEquals("foo", c.getKey());
+        }));
+        assertEquals("$$", Expression.compile("$$${foo}", NO_$$).evaluate((c, b) -> {
+            assertEquals("foo", c.getKey());
+        }));
+        assertEquals("foo$", Expression.compile("foo$${bar}", NO_$$).evaluate((c, b) -> {
+            assertEquals("bar", c.getKey());
+        }));
+        assertEquals("foo$$", Expression.compile("foo$$${bar}", NO_$$).evaluate((c, b) -> {
+            assertEquals("bar", c.getKey());
+        }));
+        assertEquals("foo$$$$", Expression.compile("foo$$$$${bar}", NO_$$).evaluate((c, b) -> {
+            assertEquals("bar", c.getKey());
+        }));
+        assertEquals("foo$$$$$$$baz", Expression.compile("foo$$$$${bar}$$$baz", NO_$$).evaluate((c, b) -> {
+            assertEquals("bar", c.getKey());
+        }));
+        assertEquals("$", Expression.compile("$${foo:bar}", NO_$$).evaluate((c, b) -> {
+            assertEquals("foo", c.getKey());
+        }));
+        assertEquals("$$", Expression.compile("$$${foo:bar}", NO_$$).evaluate((c, b) -> {
+            assertEquals("foo", c.getKey());
+        }));
+        assertEquals("$", Expression.compile("$${foo:${bar}}", NO_$$).evaluate((c, b) -> {
+            assertTrue(c.getKey().equals("foo") || c.getKey().equals("bar"));
+        }));
+        assertEquals("$", Expression.compile("$${foo:$${bar}}", NO_$$).evaluate((c, b) -> {
+            assertTrue(c.getKey().equals("foo") || c.getKey().equals("bar"));
+        }));
+
+        assertEquals("", Expression.compile("${foo}", NO_$$).evaluate((c, b) -> {
+            assertEquals("foo", c.getKey());
+        }));
+        assertEquals("", Expression.compile("${foo}${bar}", NO_$$).evaluate((c, b) -> {
+            assertTrue(c.getKey().equals("foo") || c.getKey().equals("bar"));
+        }));
+        assertEquals("foobar", Expression.compile("foo${foo}${bar}bar", NO_$$).evaluate((c, b) -> {
+            assertTrue(c.getKey().equals("foo") || c.getKey().equals("bar"));
+        }));
+        assertEquals("foo$bar", Expression.compile("foo$${foo}${bar}bar", NO_$$).evaluate((c, b) -> {
+            assertTrue(c.getKey().equals("foo") || c.getKey().equals("bar"));
+        }));
+        assertEquals("foo$bar", Expression.compile("foo$${foo${bar}}bar", NO_$$).evaluate((c, b) -> {
+            assertTrue(c.getKey().equals("foo") || c.getKey().equals("bar"));
+        }));
+        assertEquals("", Expression.compile("${}", NO_$$).evaluate((c, b) -> {
+            assertEquals("", c.getKey());
+        }));
+        assertEquals("", Expression.compile("${:}", NO_$$).evaluate((c, b) -> {
+            assertEquals("", c.getKey());
+        }));
+
+        assertEquals("\\", Expression.compile("\\${foo}", NO_$$).evaluate((c, b) -> {
+            assertEquals("foo", c.getKey());
+        }));
+        assertEquals("\\bar", Expression.compile("\\${foo}bar", NO_$$).evaluate((c, b) -> {
+            assertEquals("foo", c.getKey());
+        }));
+        assertEquals("\\$\\{%s}", Expression.compile("\\$\\{%s}", NO_$$).evaluate((c, b) -> {
+        }));
+        assertEquals("foo\\", Expression.compile("foo\\${bar}", NO_$$).evaluate((c, b) -> {
+            assertEquals("bar", c.getKey());
+        }));
+        assertEquals("foo\\\\", Expression.compile("foo\\\\${bar}", NO_$$).evaluate((c, b) -> {
+            assertEquals("bar", c.getKey());
+        }));
+
+        assertEquals("foo\\$", Expression.compile("foo\\$${bar}", NO_$$).evaluate((c, b) -> {
+            assertEquals("bar", c.getKey());
+        }));
+        assertEquals("foo$\\", Expression.compile("foo$\\${bar}", NO_$$).evaluate((c, b) -> {
+            assertEquals("bar", c.getKey());
+        }));
+        assertEquals("foo$$\\{bar}", Expression.compile("foo$$\\{bar}", NO_$$).evaluate((c, b) -> {
+        }));
+    }
+
+    @Test
+    void no$$Escapes() {
+        assertEquals("$", Expression.compile("\\$", NO_$$, ESCAPES).evaluate((c, b) -> {
+        }));
+        assertEquals("${foo}", Expression.compile("\\${foo}", NO_$$, ESCAPES).evaluate((c, b) -> {
+        }));
+
+        assertEquals("${foo}bar", Expression.compile("\\${foo}bar", NO_$$, ESCAPES).evaluate((c, b) -> {
+        }));
+        assertEquals("foo${bar}", Expression.compile("foo\\${bar}", NO_$$, ESCAPES).evaluate((c, b) -> {
+        }));
+        assertEquals("foo\\", Expression.compile("foo\\\\${bar}", NO_$$, ESCAPES).evaluate((c, b) -> {
+            assertEquals("bar", c.getKey());
+        }));
+
+        assertEquals("foo$${bar}", Expression.compile("foo$\\${bar}", NO_$$, ESCAPES).evaluate((c, b) -> {
+        }));
+        assertEquals("foo$${bar}", Expression.compile("foo$\\${bar}", NO_$$, ESCAPES).evaluate((c, b) -> {
+            assertEquals("bar", c.getKey());
         }));
     }
 }


### PR DESCRIPTION
Proposal of a new escape expressions mode (`NO_$$`) to help with:

- https://github.com/smallrye/smallrye-config/issues/1219
- https://github.com/smallrye/smallrye-config/issues/746
- https://github.com/smallrye/smallrye-config/issues/1056
- https://github.com/quarkusio/quarkus/issues/41883

Activating `NO_$$` will effectively disable the `$$` escape used for expressions.

This also allows the removal of the workaround for MP Config:
https://github.com/smallrye/smallrye-config/blob/d447b0c346e39a09c6d07c7d5ce8186bd4154037/implementation/src/main/java/io/smallrye/config/ExpressionConfigSourceInterceptor.java#L102-L123