### PR TITLE
Add resource method to list code signers

### DIFF
--- a/resource/src/main/java/io/smallrye/common/resource/JarFileResource.java
+++ b/resource/src/main/java/io/smallrye/common/resource/JarFileResource.java
@@ -8,10 +8,12 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.DirectoryStream;
 import java.nio.file.attribute.FileTime;
+import java.security.CodeSigner;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -114,6 +116,11 @@ public final class JarFileResource extends Resource {
     public Instant modifiedTime() {
         FileTime fileTime = jarEntry.getLastModifiedTime();
         return fileTime == null ? null : fileTime.toInstant();
+    }
+
+    public List<CodeSigner> codeSigners() {
+        CodeSigner[] array = jarEntry.getCodeSigners();
+        return array == null ? List.of() : List.of(array);
     }
 
     public InputStream openStream() throws IOException {

--- a/resource/src/main/java/io/smallrye/common/resource/Resource.java
+++ b/resource/src/main/java/io/smallrye/common/resource/Resource.java
@@ -14,8 +14,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.security.CodeSigner;
 import java.security.ProtectionDomain;
 import java.time.Instant;
+import java.util.List;
 import java.util.function.Function;
 
 import io.smallrye.common.constraint.Assert;
@@ -191,6 +193,15 @@ public abstract class Resource {
      */
     public Instant modifiedTime() {
         return null;
+    }
+
+    /**
+     * {@return the list of code signers for this resource}
+     * The resource must have been fully read, or else consumed {@linkplain #asBuffer() as a buffer}.
+     * By default, the base implementation returns an empty list.
+     */
+    public List<CodeSigner> codeSigners() {
+        return List.of();
     }
 
     /**


### PR DESCRIPTION
This allows for secure (spec-compliant) class loader implementation by allowing correct protection domains to be defined.