### PR TITLE
Add resource loader method to load the JAR manifest

### DIFF
--- a/resource/src/main/java/io/smallrye/common/resource/JarFileResourceLoader.java
+++ b/resource/src/main/java/io/smallrye/common/resource/JarFileResourceLoader.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.jar.Manifest;
 
 /**
  * A resource loader which corresponds to a JAR file.
@@ -77,6 +78,10 @@ public final class JarFileResourceLoader implements ResourceLoader {
 
     public URL baseUrl() {
         return base;
+    }
+
+    public Manifest manifest() throws IOException {
+        return jarFile.getManifest();
     }
 
     public void close() {

--- a/resource/src/main/java/io/smallrye/common/resource/ResourceLoader.java
+++ b/resource/src/main/java/io/smallrye/common/resource/ResourceLoader.java
@@ -2,7 +2,9 @@ package io.smallrye.common.resource;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
+import java.util.jar.Manifest;
 
 /**
  * A loader which can find resources by their path.
@@ -44,6 +46,26 @@ public interface ResourceLoader extends Closeable {
             return this;
         }
         return p -> findResource(subPath + '/' + p);
+    }
+
+    /**
+     * Get the manifest for this resource loader, if any.
+     * The default implementation constructs a new instance every time,
+     * so the caller should avoid repeated invocation of this method, caching as needed.
+     *
+     * @return the manifest, or {@code null} if no manifest was found
+     * @throws IOException if the manifest resource could not be loaded
+     */
+    default Manifest manifest() throws IOException {
+        Resource resource = findResource("META-INF/MANIFEST.MF");
+        if (resource == null) {
+            return null;
+        }
+        Manifest manifest = new Manifest();
+        try (InputStream is = resource.openStream()) {
+            manifest.read(is);
+        }
+        return manifest;
     }
 
     /**


### PR DESCRIPTION
This allows class loaders to easily find the manifest for defining packages.