### PR TITLE
Always use a URL stream handler for path-based resources

### DIFF
--- a/resource/src/main/java/io/smallrye/common/resource/PathResource.java
+++ b/resource/src/main/java/io/smallrye/common/resource/PathResource.java
@@ -3,6 +3,7 @@ package io.smallrye.common.resource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
@@ -51,7 +52,9 @@ public final class PathResource extends Resource {
         URL url = this.url;
         if (url == null) {
             try {
-                url = this.url = path.toUri().toURL();
+                URI pathUri = path.toUri();
+                // todo Java 20+: URL.of(pathUri, new ResourceURLStreamHandler(this))
+                url = this.url = new URL(null, pathUri.toASCIIString(), new ResourceURLStreamHandler(this));
             } catch (MalformedURLException e) {
                 throw new IllegalStateException("Unexpected URL problem", e);
             }

--- a/resource/src/test/java/io/smallrye/common/resource/PathResourceLoaderTests.java
+++ b/resource/src/test/java/io/smallrye/common/resource/PathResourceLoaderTests.java
@@ -1,0 +1,39 @@
+package io.smallrye.common.resource;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+public final class PathResourceLoaderTests {
+
+    @Test
+    public void testLoading() throws IOException, URISyntaxException {
+        URL myClass = PathResourceLoaderTests.class.getResource("PathResourceLoaderTests.class");
+        assumeTrue(myClass != null);
+        assumeTrue("file".equals(myClass.getProtocol()));
+        Path testClasses = Path.of(myClass.toURI()).getParent().getParent().getParent().getParent().getParent();
+        byte[] myClassBytes;
+        try (InputStream is = myClass.openStream()) {
+            assumeTrue(is != null);
+            myClassBytes = is.readAllBytes();
+        }
+        try (PathResourceLoader rl = new PathResourceLoader(testClasses)) {
+            Resource myClassRsrc = rl.findResource("io/smallrye/common/resource/PathResourceLoaderTests.class");
+            assertNotNull(myClassRsrc);
+            try (InputStream is = myClassRsrc.openStream()) {
+                assertArrayEquals(myClassBytes, is.readAllBytes());
+            }
+            URL url = myClassRsrc.url();
+            assertInstanceOf(ResourceURLConnection.class, url.openConnection());
+        }
+    }
+}


### PR DESCRIPTION
This avoids a potential problem where e.g. filesystem locks are taken by the JDK's caching implementation.

See quarkusio/quarkus#43940 for an example.