### PR TITLE
Make `ResourceUtils` public

### DIFF
--- a/resource/src/main/java/io/smallrye/common/resource/ResourceUtils.java
+++ b/resource/src/main/java/io/smallrye/common/resource/ResourceUtils.java
@@ -3,7 +3,7 @@ package io.smallrye.common.resource;
 /**
  * Miscellaneous resource-related utilities.
  */
-final class ResourceUtils {
+public final class ResourceUtils {
     private ResourceUtils() {
     }
 
@@ -39,7 +39,7 @@ final class ResourceUtils {
      * @param path the path name (must not be {@code null})
      * @return the canonical equivalent path (not {@code null})
      */
-    static String canonicalizeRelativePath(String path) {
+    public static String canonicalizeRelativePath(String path) {
         final int length = path.length();
         if (length == 0) {
             return path;


### PR DESCRIPTION
We sometimes need to canonicalize a path before handing it off to the resource loader. So, make the method public to avoid duplication.