### PR TITLE
Open JAR in MR mode in all situations

### DIFF
--- a/resource/src/main/java/io/smallrye/common/resource/JarFileResourceLoader.java
+++ b/resource/src/main/java/io/smallrye/common/resource/JarFileResourceLoader.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+import java.util.zip.ZipFile;
 
 /**
  * A resource loader which corresponds to a JAR file.
@@ -24,7 +25,7 @@ public final class JarFileResourceLoader implements ResourceLoader {
      */
     public JarFileResourceLoader(final Path jarPath) throws IOException {
         this.base = jarPath.toUri().toURL();
-        jarFile = new JarFile(jarPath.toFile());
+        jarFile = new JarFile(jarPath.toFile(), true, ZipFile.OPEN_READ, JarFile.runtimeVersion());
     }
 
     /**


### PR DESCRIPTION
Currently it is only opened as an MR JAR when loaded from the filesystem due to an oversight.