### PR TITLE
Binary search API

### DIFF
--- a/function/src/main/java/io/smallrye/common/function/ExceptionObjIntFunction.java
+++ b/function/src/main/java/io/smallrye/common/function/ExceptionObjIntFunction.java
@@ -1,0 +1,33 @@
+package io.smallrye.common.function;
+
+import java.util.Objects;
+
+/**
+ * A function which operates on an object and an integer, yielding an object.
+ *
+ * @param <T> the first argument type
+ * @param <R> the result type
+ * @param <E> the exception type
+ */
+public interface ExceptionObjIntFunction<T, R, E extends Exception> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param arg1 the first argument
+     * @param arg2 the second argument
+     * @return the function result
+     * @throws E if an exception occurs
+     */
+    R apply(T arg1, int arg2) throws E;
+
+    /**
+     * {@return a function that applies the given function to the result of this function}
+     *
+     * @param after the next function (must not be {@code null})
+     * @param <V> the final return type
+     */
+    default <V> ExceptionObjIntFunction<T, V, E> andThen(ExceptionFunction<? super R, ? extends V, ? extends E> after) {
+        Objects.requireNonNull(after);
+        return (T t, int u) -> after.apply(apply(t, u));
+    }
+}

--- a/function/src/main/java/io/smallrye/common/function/ExceptionObjIntPredicate.java
+++ b/function/src/main/java/io/smallrye/common/function/ExceptionObjIntPredicate.java
@@ -1,0 +1,48 @@
+package io.smallrye.common.function;
+
+import java.util.Objects;
+
+/**
+ * A predicate that operates on an object and an integer.
+ *
+ * @param <T> the first argument type
+ * @param <E> the exception type
+ */
+public interface ExceptionObjIntPredicate<T, E extends Exception> {
+    /**
+     * Evaluate this predicate on the given arguments.
+     *
+     * @param object the first argument
+     * @param value the second argument
+     * @return {@code true} if the predicate passes, {@code false} otherwise
+     * @throws E if an exception occurs
+     */
+    boolean test(T object, int value) throws E;
+
+    /**
+     * {@return a predicate which is {@code true} only when this and the given predicate return {@code true}}
+     *
+     * @param other the other predicate (must not be {@code null})
+     */
+    default ExceptionObjIntPredicate<T, E> and(ExceptionObjIntPredicate<? super T, ? extends E> other) {
+        Objects.requireNonNull(other);
+        return (t, i) -> test(t, i) && other.test(t, i);
+    }
+
+    /**
+     * {@return a predicate which is {@code true} when this predicate is {@code false}, and vice-versa}
+     */
+    default ExceptionObjIntPredicate<T, E> negate() {
+        return (t, i) -> !test(t, i);
+    }
+
+    /**
+     * {@return a predicate which is {@code true} when either this or the given predicate return {@code true}}
+     *
+     * @param other the other predicate (must not be {@code null})
+     */
+    default ExceptionObjIntPredicate<T, E> or(ExceptionObjIntPredicate<? super T, ? extends E> other) {
+        Objects.requireNonNull(other);
+        return (t, i) -> test(t, i) || other.test(t, i);
+    }
+}

--- a/function/src/main/java/io/smallrye/common/function/ExceptionObjLongFunction.java
+++ b/function/src/main/java/io/smallrye/common/function/ExceptionObjLongFunction.java
@@ -1,0 +1,33 @@
+package io.smallrye.common.function;
+
+import java.util.Objects;
+
+/**
+ * A function which operates on an object and a long integer, yielding an object.
+ *
+ * @param <T> the first argument type
+ * @param <R> the result type
+ * @param <E> the exception type
+ */
+public interface ExceptionObjLongFunction<T, R, E extends Exception> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param arg1 the first argument
+     * @param arg2 the second argument
+     * @return the function result
+     * @throws E if an exception occurs
+     */
+    R apply(T arg1, long arg2) throws E;
+
+    /**
+     * {@return a function that applies the given function to the result of this function}
+     *
+     * @param after the next function (must not be {@code null})
+     * @param <V> the final return type
+     */
+    default <V> ExceptionObjLongFunction<T, V, E> andThen(ExceptionFunction<? super R, ? extends V, ? extends E> after) {
+        Objects.requireNonNull(after);
+        return (T t, long u) -> after.apply(apply(t, u));
+    }
+}

--- a/function/src/main/java/io/smallrye/common/function/ExceptionObjLongPredicate.java
+++ b/function/src/main/java/io/smallrye/common/function/ExceptionObjLongPredicate.java
@@ -1,0 +1,48 @@
+package io.smallrye.common.function;
+
+import java.util.Objects;
+
+/**
+ * A predicate that operates on an object and a long integer.
+ *
+ * @param <T> the first argument type
+ * @param <E> the exception type
+ */
+public interface ExceptionObjLongPredicate<T, E extends Exception> {
+    /**
+     * Evaluate this predicate on the given arguments.
+     *
+     * @param object the first argument
+     * @param value the second argument
+     * @return {@code true} if the predicate passes, {@code false} otherwise
+     * @throws E if an exception occurs
+     */
+    boolean test(T object, long value) throws E;
+
+    /**
+     * {@return a predicate which is {@code true} only when this and the given predicate return {@code true}}
+     *
+     * @param other the other predicate (must not be {@code null})
+     */
+    default ExceptionObjLongPredicate<T, E> and(ExceptionObjLongPredicate<? super T, ? extends E> other) {
+        Objects.requireNonNull(other);
+        return (t, i) -> test(t, i) && other.test(t, i);
+    }
+
+    /**
+     * {@return a predicate which is {@code true} when this predicate is {@code false}, and vice-versa}
+     */
+    default ExceptionObjLongPredicate<T, E> negate() {
+        return (t, i) -> !test(t, i);
+    }
+
+    /**
+     * {@return a predicate which is {@code true} when either this or the given predicate return {@code true}}
+     *
+     * @param other the other predicate (must not be {@code null})
+     */
+    default ExceptionObjLongPredicate<T, E> or(ExceptionObjLongPredicate<? super T, ? extends E> other) {
+        Objects.requireNonNull(other);
+        return (t, i) -> test(t, i) || other.test(t, i);
+    }
+}

--- a/function/src/main/java/io/smallrye/common/function/ObjIntFunction.java
+++ b/function/src/main/java/io/smallrye/common/function/ObjIntFunction.java
@@ -1,0 +1,32 @@
+package io.smallrye.common.function;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * A function which operates on an object and an integer, yielding an object.
+ *
+ * @param <T> the first argument type
+ * @param <R> the result type
+ */
+public interface ObjIntFunction<T, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param arg1 the first argument
+     * @param arg2 the second argument
+     * @return the function result
+     */
+    R apply(T arg1, int arg2);
+
+    /**
+     * {@return a function that applies the given function to the result of this function}
+     *
+     * @param after the next function (must not be {@code null})
+     * @param <V> the final return type
+     */
+    default <V> ObjIntFunction<T, V> andThen(Function<? super R, ? extends V> after) {
+        Objects.requireNonNull(after);
+        return (T t, int u) -> after.apply(apply(t, u));
+    }
+}

--- a/function/src/main/java/io/smallrye/common/function/ObjIntPredicate.java
+++ b/function/src/main/java/io/smallrye/common/function/ObjIntPredicate.java
@@ -1,0 +1,46 @@
+package io.smallrye.common.function;
+
+import java.util.Objects;
+
+/**
+ * A predicate that operates on an object and an integer.
+ *
+ * @param <T> the first argument type
+ */
+public interface ObjIntPredicate<T> {
+    /**
+     * Evaluate this predicate on the given arguments.
+     *
+     * @param object the first argument
+     * @param value the second argument
+     * @return {@code true} if the predicate passes, {@code false} otherwise
+     */
+    boolean test(T object, int value);
+
+    /**
+     * {@return a predicate which is {@code true} only when this and the given predicate return {@code true}}
+     *
+     * @param other the other predicate (must not be {@code null})
+     */
+    default ObjIntPredicate<T> and(ObjIntPredicate<? super T> other) {
+        Objects.requireNonNull(other);
+        return (t, i) -> test(t, i) && other.test(t, i);
+    }
+
+    /**
+     * {@return a predicate which is {@code true} when this predicate is {@code false}, and vice-versa}
+     */
+    default ObjIntPredicate<T> negate() {
+        return (t, i) -> !test(t, i);
+    }
+
+    /**
+     * {@return a predicate which is {@code true} when either this or the given predicate return {@code true}}
+     *
+     * @param other the other predicate (must not be {@code null})
+     */
+    default ObjIntPredicate<T> or(ObjIntPredicate<? super T> other) {
+        Objects.requireNonNull(other);
+        return (t, i) -> test(t, i) || other.test(t, i);
+    }
+}

--- a/function/src/main/java/io/smallrye/common/function/ObjLongFunction.java
+++ b/function/src/main/java/io/smallrye/common/function/ObjLongFunction.java
@@ -1,0 +1,32 @@
+package io.smallrye.common.function;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * A function which operates on an object and a long integer, yielding an object.
+ *
+ * @param <T> the first argument type
+ * @param <R> the result type
+ */
+public interface ObjLongFunction<T, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param arg1 the first argument
+     * @param arg2 the second argument
+     * @return the function result
+     */
+    R apply(T arg1, long arg2);
+
+    /**
+     * {@return a function that applies the given function to the result of this function}
+     *
+     * @param after the next function (must not be {@code null})
+     * @param <V> the final return type
+     */
+    default <V> ObjLongFunction<T, V> andThen(Function<? super R, ? extends V> after) {
+        Objects.requireNonNull(after);
+        return (T t, long u) -> after.apply(apply(t, u));
+    }
+}

--- a/function/src/main/java/io/smallrye/common/function/ObjLongPredicate.java
+++ b/function/src/main/java/io/smallrye/common/function/ObjLongPredicate.java
@@ -1,0 +1,46 @@
+package io.smallrye.common.function;
+
+import java.util.Objects;
+
+/**
+ * A predicate that operates on an object and a long integer.
+ *
+ * @param <T> the first argument type
+ */
+public interface ObjLongPredicate<T> {
+    /**
+     * Evaluate this predicate on the given arguments.
+     *
+     * @param object the first argument
+     * @param value the second argument
+     * @return {@code true} if the predicate passes, {@code false} otherwise
+     */
+    boolean test(T object, long value);
+
+    /**
+     * {@return a predicate which is {@code true} only when this and the given predicate return {@code true}}
+     *
+     * @param other the other predicate (must not be {@code null})
+     */
+    default ObjLongPredicate<T> and(ObjLongPredicate<? super T> other) {
+        Objects.requireNonNull(other);
+        return (t, i) -> test(t, i) && other.test(t, i);
+    }
+
+    /**
+     * {@return a predicate which is {@code true} when this predicate is {@code false}, and vice-versa}
+     */
+    default ObjLongPredicate<T> negate() {
+        return (t, i) -> !test(t, i);
+    }
+
+    /**
+     * {@return a predicate which is {@code true} when either this or the given predicate return {@code true}}
+     *
+     * @param other the other predicate (must not be {@code null})
+     */
+    default ObjLongPredicate<T> or(ObjLongPredicate<? super T> other) {
+        Objects.requireNonNull(other);
+        return (t, i) -> test(t, i) || other.test(t, i);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <module>os</module>
         <module>ref</module>
         <module>resource</module>
+        <module>search</module>
         <module>version</module>
         <module>vertx-context</module>
     </modules>

--- a/search/pom.xml
+++ b/search/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye.common</groupId>
+        <artifactId>smallrye-common-parent</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smallrye-common-search</artifactId>
+
+    <name>SmallRye Common: Search</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-common-function</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <properties>
+                <argLine>@{jacocoArgLine}</argLine>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>report</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+
+</project>

--- a/search/src/main/java/io/smallrye/common/search/BinarySearch.java
+++ b/search/src/main/java/io/smallrye/common/search/BinarySearch.java
@@ -1,0 +1,1155 @@
+package io.smallrye.common.search;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.BinaryOperator;
+import java.util.function.IntBinaryOperator;
+import java.util.function.IntPredicate;
+import java.util.function.LongBinaryOperator;
+import java.util.function.LongPredicate;
+import java.util.function.Predicate;
+
+import io.smallrye.common.function.ObjIntFunction;
+import io.smallrye.common.function.ObjIntPredicate;
+import io.smallrye.common.function.ObjLongFunction;
+import io.smallrye.common.function.ObjLongPredicate;
+
+/**
+ * A utility class which provides multiple variations on binary searching.
+ *
+ * <h2>Ranges</h2>
+ *
+ * The binary search algorithm operates over a range of values.
+ * The search will always return in logarithmic time with respect to the search interval.
+ * This implementation supports multiple kinds of value ranges:
+ * <ul>
+ * <li>{@code int} via the {@link #intRange()} method</li>
+ * <li>{@code long} via the {@link #longRange()} method</li>
+ * <li>Object ranges via the {@link #objRange()} method</li>
+ * </ul>
+ *
+ * Each of these methods returns an object with {@code find()} methods that perform variations on the binary search.
+ *
+ * <h3>Range predicates</h3>
+ *
+ * Ranges are searched by predicate.
+ * The predicate is evaluated for the lowest value within the range
+ * (that is, the value closest to the {@code from} argument) for which it returns {@code true}.
+ * If no value satisfies the predicate, the highest value (that is, the value given for the {@code to} argument) is returned.
+ * The value returned by each {@code find()} method is always within the range {@code [from, to]}.
+ * <p>
+ * In order to be well-defined, the predicate must be <em>continuous</em>, which is to say that
+ * given some value {@code n},
+ * the predicate must return {@code false} for all {@code < n} and {@code true} for all {@code >= n}
+ * when {@code from ≤ n ≤ to}.
+ * If this constraint does not hold, then the results of the search will not be well-defined.
+ * The behavior of the predicate outside of this range does not affect the well-definedness of the search operation.
+ *
+ * <h3>Inverted ranges</h3>
+ *
+ * It is possible to search over an inverted range, i.e.
+ * a range for which {@code to} is numerically lower than {@code from}.
+ * While such searches are well-defined, it should be noted that the {@code from} bound
+ * remains inclusive while the {@code to} bound remains exclusive,
+ * which might be surprising in some circumstances.
+ */
+public final class BinarySearch {
+    private BinarySearch() {
+    }
+
+    /**
+     * {@return an object which can perform binary searches over an integer range (not <code>null</code>)}
+     * The returned object operates on a signed range by default.
+     *
+     * @see IntRange#unsigned()
+     */
+    public static IntRange intRange() {
+        return IntRange.signed;
+    }
+
+    /**
+     * {@return an object which can perform binary searches over a long integer range (not <code>null</code>)}
+     * The returned object operates on a signed range by default.
+     *
+     * @see LongRange#unsigned()
+     */
+    public static LongRange longRange() {
+        return LongRange.signed;
+    }
+
+    /**
+     * {@return an object which can perform binary searches over an object range (not <code>null</code>)}
+     */
+    public static ObjRange objRange() {
+        return ObjRange.instance;
+    }
+
+    /**
+     * A getter function which can satisfy {@link ObjIntFunction ObjIntFunction&lt;E[], E>} for accessing
+     * values in an array.
+     *
+     * @param array the array (must not be {@code null})
+     * @param index the array index
+     * @return the array value at the index
+     * @param <E> the array element type
+     */
+    public static <E> E getFromArray(E[] array, int index) {
+        return array[index];
+    }
+
+    /**
+     * Search operations which apply over an {@code int} range.
+     */
+    public static final class IntRange {
+        private final IntBinaryOperator midpoint;
+        private final InCollection inCollection;
+
+        private IntRange(final IntBinaryOperator midpoint) {
+            this.midpoint = midpoint;
+            inCollection = new InCollection(midpoint);
+        }
+
+        private static final IntRange signed = new IntRange(BinarySearch::signedMidpoint);
+        private static final IntRange unsigned = new IntRange(BinarySearch::unsignedMidpoint);
+
+        /**
+         * Get the lowest index within the given range that satisfies the given test.
+         *
+         * @param from the low end of the range (inclusive)
+         * @param to the high end of the range (exclusive)
+         * @param test the test (must not be {@code null})
+         * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the test
+         *         within the range
+         */
+        public int find(int from, int to, IntPredicate test) {
+            return searchInt(from, to, test, null, null, null, midpoint, IntRange::find0);
+        }
+
+        private static boolean find0(int idx, IntPredicate test, Void ignored0, Void ignored1, Void ignored2) {
+            return test.test(idx);
+        }
+
+        /**
+         * {@return search operations over a signed-integer space}
+         */
+        public IntRange signed() {
+            return signed;
+        }
+
+        /**
+         * {@return search operations over an unsigned-integer space}
+         */
+        public IntRange unsigned() {
+            return unsigned;
+        }
+
+        /**
+         * {@return search operations over a space defined by a custom midpoint function}
+         */
+        public CustomMidpoint customMidpoint() {
+            return CustomMidpoint.instance;
+        }
+
+        /**
+         * {@return search operations over a collection using the current signedness rules for the midpoint function}
+         */
+        public InCollection inCollection() {
+            return inCollection;
+        }
+
+        /**
+         * Search operations which apply over an {@code int} range using a custom midpoint function.
+         */
+        public static final class CustomMidpoint {
+            private static final CustomMidpoint instance = new CustomMidpoint();
+
+            private CustomMidpoint() {
+            }
+
+            /**
+             * Get the lowest index within the given range that satisfies the given test.
+             *
+             * @param from the low end of the range (inclusive)
+             * @param to the high end of the range (exclusive)
+             * @param midpoint the midpoint function (must not be {@code null})
+             * @param test the test (must not be {@code null})
+             * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the test
+             *         within the range
+             */
+            public int find(int from, int to, IntBinaryOperator midpoint, IntPredicate test) {
+                return searchInt(from, to, test, null, null, null, midpoint, CustomMidpoint::find0);
+            }
+
+            private static boolean find0(int idx, IntPredicate test, Void ignored0, Void ignored1, Void ignored2) {
+                return test.test(idx);
+            }
+
+            /**
+             * {@return search operations over a collection using a custom midpoint function}
+             */
+            public InCollection inCollection() {
+                return InCollection.instance;
+            }
+
+            /**
+             * Search operations within a collection using a custom midpoint function.
+             */
+            public static final class InCollection {
+                private static final InCollection instance = new InCollection();
+
+                private InCollection() {
+                }
+
+                /**
+                 * Get the lowest index within the given range that satisfies the given test.
+                 *
+                 * @param collection the collection object (must not be {@code null})
+                 * @param from the low end of the range (inclusive)
+                 * @param to the high end of the range (exclusive)
+                 * @param midpoint the midpoint function (must not be {@code null})
+                 * @param test the test (must not be {@code null})
+                 * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the
+                 *         test within the range
+                 * @param <C> the collection type
+                 */
+                public <C> int find(C collection, int from, int to, IntBinaryOperator midpoint, ObjIntPredicate<C> test) {
+                    return searchInt(from, to, collection, test, (Void) null, (Void) null, midpoint,
+                            IntRange.InCollection::find0);
+                }
+
+                /**
+                 * Get the lowest index within the given random-access list that satisfies the given test.
+                 *
+                 * @param list the list object (must not be {@code null})
+                 * @param midpoint the midpoint function (must not be {@code null})
+                 * @param test the test (must not be {@code null})
+                 * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the
+                 *         test within the range
+                 * @param <L> the list type
+                 */
+                public <L extends List<?>> int find(L list, IntBinaryOperator midpoint, ObjIntPredicate<L> test) {
+                    return find(list, 0, list.size(), midpoint, test);
+                }
+
+                /**
+                 * {@return search operations which operate by an extracted key}
+                 */
+                public ByKey byKey() {
+                    return ByKey.instance;
+                }
+
+                /**
+                 * Search operations within a collection which operate on an extracted key using a custom midpoint function.
+                 */
+                public static final class ByKey {
+                    private static final ByKey instance = new ByKey();
+
+                    private ByKey() {
+                    }
+
+                    /**
+                     * Get the lowest index within the given range that satisfies the given test.
+                     *
+                     * @param collection the collection object (must not be {@code null})
+                     * @param from the low end of the range (inclusive)
+                     * @param to the high end of the range (exclusive)
+                     * @param midpoint the midpoint function (must not be {@code null})
+                     * @param keyExtractor the key extraction function (must not be {@code null})
+                     * @param keyTester the test for the key (must not be {@code null})
+                     * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy
+                     *         the test within the range
+                     * @param <C> the collection type
+                     * @param <K> the key type
+                     */
+                    public <C, K> int find(C collection, int from, int to, IntBinaryOperator midpoint,
+                            ObjIntFunction<C, K> keyExtractor, Predicate<K> keyTester) {
+                        return searchInt(from, to, collection, keyExtractor, keyTester, (Void) null, midpoint,
+                                IntRange.InCollection.ByKey::find0);
+                    }
+
+                    /**
+                     * Get the lowest index within the given range that satisfies the given test for the search value.
+                     *
+                     * @param collection the collection object (must not be {@code null})
+                     * @param searchVal the value to search for
+                     * @param from the low end of the range (inclusive)
+                     * @param to the high end of the range (exclusive)
+                     * @param midpoint the midpoint function (must not be {@code null})
+                     * @param keyExtractor the key extraction function (must not be {@code null})
+                     * @param keyTester the test for the key (must not be {@code null})
+                     * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy
+                     *         the test within the range
+                     * @param <C> the collection type
+                     * @param <K> the key type
+                     * @param <V> the search value type
+                     */
+                    public <C, K, V> int find(C collection, V searchVal, int from, int to, IntBinaryOperator midpoint,
+                            ObjIntFunction<C, K> keyExtractor,
+                            BiPredicate<V, K> keyTester) {
+                        return searchInt(from, to, collection, searchVal, keyExtractor, keyTester, midpoint,
+                                IntRange.InCollection.ByKey::find1);
+                    }
+
+                    /**
+                     * Get the lowest index within the given range whose key is equal to or greater than
+                     * the search key, according to the {@linkplain Comparator#naturalOrder() natural order} of
+                     * the search space.
+                     *
+                     * @param collection the collection object (must not be {@code null})
+                     * @param searchKey the key to search for (must not be {@code null})
+                     * @param from the low end of the range (inclusive)
+                     * @param to the high end of the range (exclusive)
+                     * @param midpoint the midpoint function (must not be {@code null})
+                     * @param keyExtractor the key extraction function (must not be {@code null})
+                     * @return the lowest index within the range which satisfies the condition, or {@code to} if no values
+                     *         satisfy the condition within the range
+                     * @param <C> the collection type
+                     * @param <K> the key type
+                     */
+                    public <C, K extends Comparable<? super K>> int findFirst(C collection, K searchKey, int from, int to,
+                            IntBinaryOperator midpoint, ObjIntFunction<C, K> keyExtractor) {
+                        return findFirst(collection, searchKey, from, to, midpoint, keyExtractor, Comparator.naturalOrder());
+                    }
+
+                    /**
+                     * Get the lowest index within the given range whose key is equal to or greater than
+                     * the search key, according to the given comparator.
+                     *
+                     * @param collection the collection object (must not be {@code null})
+                     * @param searchKey the key to search for (must not be {@code null})
+                     * @param from the low end of the range (inclusive)
+                     * @param to the high end of the range (exclusive)
+                     * @param midpoint the midpoint function (must not be {@code null})
+                     * @param keyExtractor the key extraction function (must not be {@code null})
+                     * @param cmp the comparator (must not be {@code null})
+                     * @return the lowest index within the range which satisfies the condition, or {@code to} if no values
+                     *         satisfy the condition within the range
+                     * @param <C> the collection type
+                     * @param <K> the key type
+                     */
+                    public <C, K> int findFirst(C collection, K searchKey, int from, int to, IntBinaryOperator midpoint,
+                            ObjIntFunction<C, K> keyExtractor,
+                            Comparator<? super K> cmp) {
+                        return searchInt(from, to, collection, searchKey, keyExtractor, cmp, midpoint,
+                                IntRange.InCollection.ByKey::find2);
+                    }
+                }
+            }
+        }
+
+        /**
+         * Search operations within a collection.
+         */
+        public static final class InCollection {
+            private final IntBinaryOperator midpoint;
+            private final ByKey byKey;
+
+            private InCollection(final IntBinaryOperator midpoint) {
+                this.midpoint = midpoint;
+                byKey = new ByKey(midpoint);
+            }
+
+            /**
+             * Get the lowest index within the given range that satisfies the given test.
+             *
+             * @param collection the collection object (must not be {@code null})
+             * @param from the low end of the range (inclusive)
+             * @param to the high end of the range (exclusive)
+             * @param test the test (must not be {@code null})
+             * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the test
+             *         within the range
+             * @param <C> the collection type
+             */
+            public <C> int find(C collection, int from, int to, ObjIntPredicate<C> test) {
+                return searchInt(from, to, collection, test, (Void) null, (Void) null, midpoint, InCollection::find0);
+            }
+
+            /**
+             * Get the lowest index within the given random-access list that satisfies the given test.
+             *
+             * @param list the list object (must not be {@code null})
+             * @param test the test (must not be {@code null})
+             * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the test
+             *         within the range
+             * @param <L> the list type
+             */
+            public <L extends List<?>> int find(L list, ObjIntPredicate<L> test) {
+                return find(list, 0, list.size(), test);
+            }
+
+            private static <C> boolean find0(int idx, C collection, ObjIntPredicate<C> test, Void ignored0, Void ignored1) {
+                return test.test(collection, idx);
+            }
+
+            /**
+             * {@return search operations which operate by an extracted key}
+             */
+            public ByKey byKey() {
+                return byKey;
+            }
+
+            /**
+             * Search operations within a collection which operate on an extracted key.
+             */
+            public static final class ByKey {
+                private final IntBinaryOperator midpoint;
+
+                private ByKey(IntBinaryOperator midpoint) {
+                    this.midpoint = midpoint;
+                }
+
+                /**
+                 * Get the lowest index within the given range that satisfies the given test.
+                 *
+                 * @param collection the collection object (must not be {@code null})
+                 * @param from the low end of the range (inclusive)
+                 * @param to the high end of the range (exclusive)
+                 * @param keyExtractor the key extraction function (must not be {@code null})
+                 * @param keyTester the test for the key (must not be {@code null})
+                 * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the
+                 *         test within the range
+                 * @param <C> the collection type
+                 * @param <K> the key type
+                 */
+                public <C, K> int find(C collection, int from, int to, ObjIntFunction<C, K> keyExtractor,
+                        Predicate<K> keyTester) {
+                    return searchInt(from, to, collection, keyExtractor, keyTester, (Void) null, midpoint, ByKey::find0);
+                }
+
+                private static <C, K> boolean find0(int idx, C collection, ObjIntFunction<C, K> keyExtractor,
+                        Predicate<K> keyTester, Void ignored) {
+                    return keyTester.test(keyExtractor.apply(collection, idx));
+                }
+
+                /**
+                 * Get the lowest index within the given range that satisfies the given test for the search value.
+                 *
+                 * @param collection the collection object (must not be {@code null})
+                 * @param searchVal the value to search for
+                 * @param from the low end of the range (inclusive)
+                 * @param to the high end of the range (exclusive)
+                 * @param keyExtractor the key extraction function (must not be {@code null})
+                 * @param keyTester the test for the key (must not be {@code null})
+                 * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the
+                 *         test within the range
+                 * @param <C> the collection type
+                 * @param <K> the key type
+                 * @param <V> the value type
+                 */
+                public <C, K, V> int find(C collection, V searchVal, int from, int to, ObjIntFunction<C, K> keyExtractor,
+                        BiPredicate<V, K> keyTester) {
+                    return searchInt(from, to, collection, searchVal, keyExtractor, keyTester, midpoint, ByKey::find1);
+                }
+
+                private static <C, K, V> boolean find1(int idx, C collection, V searchVal, ObjIntFunction<C, K> keyExtractor,
+                        BiPredicate<V, K> keyTester) {
+                    return keyTester.test(searchVal, keyExtractor.apply(collection, idx));
+                }
+
+                /**
+                 * Get the lowest index within the given range whose key is equal to or greater than
+                 * the search key, according to the {@linkplain Comparator#naturalOrder() natural order} of
+                 * the search space.
+                 *
+                 * @param collection the collection object (must not be {@code null})
+                 * @param searchKey the key to search for (must not be {@code null})
+                 * @param from the low end of the range (inclusive)
+                 * @param to the high end of the range (exclusive)
+                 * @param keyExtractor the key extraction function (must not be {@code null})
+                 * @return the lowest index within the range which satisfies the condition, or {@code to} if no values satisfy
+                 *         the condition within the range
+                 * @param <C> the collection type
+                 * @param <K> the key type
+                 */
+                public <C, K extends Comparable<? super K>> int findFirst(C collection, K searchKey, int from, int to,
+                        ObjIntFunction<C, K> keyExtractor) {
+                    return findFirst(collection, searchKey, from, to, keyExtractor, Comparator.naturalOrder());
+                }
+
+                /**
+                 * Get the lowest index within the given range whose key is equal to or greater than
+                 * the search key, according to the given comparator.
+                 *
+                 * @param collection the collection object (must not be {@code null})
+                 * @param searchKey the key to search for (must not be {@code null})
+                 * @param from the low end of the range (inclusive)
+                 * @param to the high end of the range (exclusive)
+                 * @param keyExtractor the key extraction function (must not be {@code null})
+                 * @param cmp the comparator (must not be {@code null})
+                 * @return the lowest index within the range which satisfies the condition, or {@code to} if no values satisfy
+                 *         the condition within the range
+                 * @param <C> the collection type
+                 * @param <K> the key type
+                 */
+                public <C, K> int findFirst(C collection, K searchKey, int from, int to, ObjIntFunction<C, K> keyExtractor,
+                        Comparator<? super K> cmp) {
+                    return searchInt(from, to, collection, searchKey, keyExtractor, cmp, midpoint, ByKey::find2);
+                }
+
+                private static <C, K> boolean find2(int idx, C collection, K searchKey, ObjIntFunction<C, K> keyExtractor,
+                        Comparator<? super K> cmp) {
+                    return cmp.compare(searchKey, keyExtractor.apply(collection, idx)) >= 0;
+                }
+            }
+        }
+    }
+
+    /**
+     * Search operations which apply over an {@code long} range.
+     */
+    public static final class LongRange {
+        private final LongBinaryOperator midpoint;
+        private final InCollection inCollection;
+
+        private LongRange(final LongBinaryOperator midpoint) {
+            this.midpoint = midpoint;
+            inCollection = new InCollection(midpoint);
+        }
+
+        private static final LongRange signed = new LongRange(BinarySearch::signedMidpoint);
+        private static final LongRange unsigned = new LongRange(BinarySearch::unsignedMidpoint);
+
+        /**
+         * Get the lowest index within the given range that satisfies the given test.
+         *
+         * @param from the low end of the range (inclusive)
+         * @param to the high end of the range (exclusive)
+         * @param test the test (must not be {@code null})
+         * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the test
+         *         within the range
+         */
+        public long find(long from, long to, LongPredicate test) {
+            return searchLong(from, to, test, null, null, null, midpoint, LongRange::find0);
+        }
+
+        private static boolean find0(long idx, LongPredicate test, Void ignored0, Void ignored1, Void ignored2) {
+            return test.test(idx);
+        }
+
+        /**
+         * {@return search operations over a signed-integer space}
+         */
+        public LongRange signed() {
+            return signed;
+        }
+
+        /**
+         * {@return search operations over an unsigned-integer space}
+         */
+        public LongRange unsigned() {
+            return unsigned;
+        }
+
+        /**
+         * {@return search operations over a space defined by a custom midpoint function}
+         */
+        public CustomMidpoint customMidpoint() {
+            return CustomMidpoint.instance;
+        }
+
+        /**
+         * {@return search operations over a collection using the current signedness rules for the midpoint function}
+         */
+        public InCollection inCollection() {
+            return inCollection;
+        }
+
+        /**
+         * Search operations which apply over an {@code long} range using a custom midpoint function.
+         */
+        public static final class CustomMidpoint {
+            private static final CustomMidpoint instance = new CustomMidpoint();
+
+            private CustomMidpoint() {
+            }
+
+            /**
+             * Get the lowest index within the given range that satisfies the given test.
+             *
+             * @param from the low end of the range (inclusive)
+             * @param to the high end of the range (exclusive)
+             * @param midpoint the midpoint function (must not be {@code null})
+             * @param test the test (must not be {@code null})
+             * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the test
+             *         within the range
+             */
+            public long find(long from, long to, LongBinaryOperator midpoint, LongPredicate test) {
+                return searchLong(from, to, test, null, null, null, midpoint, CustomMidpoint::find0);
+            }
+
+            private static boolean find0(long idx, LongPredicate test, Void ignored0, Void ignored1, Void ignored2) {
+                return test.test(idx);
+            }
+
+            /**
+             * {@return search operations over a collection using a custom midpoint function}
+             */
+            public InCollection inCollection() {
+                return InCollection.instance;
+            }
+
+            /**
+             * Search operations within a collection using a custom midpoint function.
+             */
+            public static final class InCollection {
+                private static final InCollection instance = new InCollection();
+
+                private InCollection() {
+                }
+
+                /**
+                 * Get the lowest index within the given range that satisfies the given test.
+                 *
+                 * @param collection the collection object (must not be {@code null})
+                 * @param from the low end of the range (inclusive)
+                 * @param to the high end of the range (exclusive)
+                 * @param midpoint the midpoint function (must not be {@code null})
+                 * @param test the test (must not be {@code null})
+                 * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the
+                 *         test within the range
+                 * @param <C> the collection type
+                 */
+                public <C> long find(C collection, long from, long to, LongBinaryOperator midpoint, ObjLongPredicate<C> test) {
+                    return searchLong(from, to, collection, test, (Void) null, (Void) null, midpoint,
+                            LongRange.InCollection::find0);
+                }
+
+                /**
+                 * {@return search operations which operate by an extracted key}
+                 */
+                public ByKey byKey() {
+                    return ByKey.instance;
+                }
+
+                /**
+                 * Search operations within a collection which operate on an extracted key using a custom midpoint function.
+                 */
+                public static final class ByKey {
+                    private static final ByKey instance = new ByKey();
+
+                    private ByKey() {
+                    }
+
+                    /**
+                     * Get the lowest index within the given range that satisfies the given test.
+                     *
+                     * @param collection the collection object (must not be {@code null})
+                     * @param from the low end of the range (inclusive)
+                     * @param to the high end of the range (exclusive)
+                     * @param midpoint the midpoint function (must not be {@code null})
+                     * @param keyExtractor the key extraction function (must not be {@code null})
+                     * @param keyTester the test for the key (must not be {@code null})
+                     * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy
+                     *         the test within the range
+                     * @param <C> the collection type
+                     * @param <K> the key type
+                     */
+                    public <C, K> long find(C collection, long from, long to, LongBinaryOperator midpoint,
+                            ObjLongFunction<C, K> keyExtractor, Predicate<K> keyTester) {
+                        return searchLong(from, to, collection, keyExtractor, keyTester, (Void) null, midpoint,
+                                LongRange.InCollection.ByKey::find0);
+                    }
+
+                    /**
+                     * Get the lowest index within the given range that satisfies the given test for the search value.
+                     *
+                     * @param collection the collection object (must not be {@code null})
+                     * @param searchVal the value to search for
+                     * @param from the low end of the range (inclusive)
+                     * @param to the high end of the range (exclusive)
+                     * @param midpoint the midpoint function (must not be {@code null})
+                     * @param keyExtractor the key extraction function (must not be {@code null})
+                     * @param keyTester the test for the key (must not be {@code null})
+                     * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy
+                     *         the test within the range
+                     * @param <C> the collection type
+                     * @param <K> the key type
+                     * @param <V> the value type
+                     */
+                    public <C, K, V> long find(C collection, V searchVal, long from, long to, LongBinaryOperator midpoint,
+                            ObjLongFunction<C, K> keyExtractor, BiPredicate<V, K> keyTester) {
+                        return searchLong(from, to, collection, searchVal, keyExtractor, keyTester, midpoint,
+                                LongRange.InCollection.ByKey::find1);
+                    }
+
+                    /**
+                     * Get the lowest index within the given range whose key is equal to or greater than
+                     * the search key, according to the {@linkplain Comparator#naturalOrder() natural order} of
+                     * the search space.
+                     *
+                     * @param collection the collection object (must not be {@code null})
+                     * @param searchKey the key to search for (must not be {@code null})
+                     * @param from the low end of the range (inclusive)
+                     * @param to the high end of the range (exclusive)
+                     * @param midpoint the midpoint function (must not be {@code null})
+                     * @param keyExtractor the key extraction function (must not be {@code null})
+                     * @return the lowest index within the range which satisfies the condition, or {@code to} if no values
+                     *         satisfy the condition within the range
+                     * @param <C> the collection type
+                     * @param <K> the key type
+                     */
+                    public <C, K extends Comparable<? super K>> long findFirst(C collection, K searchKey, long from, long to,
+                            LongBinaryOperator midpoint, ObjLongFunction<C, K> keyExtractor) {
+                        return findFirst(collection, searchKey, from, to, midpoint, keyExtractor, Comparator.naturalOrder());
+                    }
+
+                    /**
+                     * Get the lowest index within the given range whose key is equal to or greater than
+                     * the search key, according to the given comparator.
+                     *
+                     * @param collection the collection object (must not be {@code null})
+                     * @param searchKey the key to search for (must not be {@code null})
+                     * @param from the low end of the range (inclusive)
+                     * @param to the high end of the range (exclusive)
+                     * @param midpoint the midpoint function (must not be {@code null})
+                     * @param keyExtractor the key extraction function (must not be {@code null})
+                     * @param cmp the comparator (must not be {@code null})
+                     * @return the lowest index within the range which satisfies the condition, or {@code to} if no values
+                     *         satisfy the condition within the range
+                     * @param <C> the collection type
+                     * @param <K> the key type
+                     */
+                    public <C, K> long findFirst(C collection, K searchKey, long from, long to, LongBinaryOperator midpoint,
+                            ObjLongFunction<C, K> keyExtractor, Comparator<? super K> cmp) {
+                        return searchLong(from, to, collection, searchKey, keyExtractor, cmp, midpoint,
+                                LongRange.InCollection.ByKey::find2);
+                    }
+                }
+            }
+        }
+
+        /**
+         * Search operations within a collection.
+         */
+        public static final class InCollection {
+            private final LongBinaryOperator midpoint;
+            private final ByKey byKey;
+
+            private InCollection(final LongBinaryOperator midpoint) {
+                this.midpoint = midpoint;
+                byKey = new ByKey(midpoint);
+            }
+
+            /**
+             * Get the lowest index within the given range that satisfies the given test.
+             *
+             * @param collection the collection object (must not be {@code null})
+             * @param from the low end of the range (inclusive)
+             * @param to the high end of the range (exclusive)
+             * @param test the test (must not be {@code null})
+             * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the test
+             *         within the range
+             * @param <C> the collection type
+             */
+            public <C> long find(C collection, long from, long to, ObjLongPredicate<C> test) {
+                return searchLong(from, to, collection, test, (Void) null, (Void) null, midpoint, InCollection::find0);
+            }
+
+            private static <C> boolean find0(long idx, C collection, ObjLongPredicate<C> test, Void ignored0, Void ignored1) {
+                return test.test(collection, idx);
+            }
+
+            /**
+             * {@return search operations which operate by an extracted key}
+             */
+            public ByKey byKey() {
+                return byKey;
+            }
+
+            /**
+             * Search operations within a collection which operate on an extracted key.
+             */
+            public static final class ByKey {
+                private final LongBinaryOperator midpoint;
+
+                private ByKey(LongBinaryOperator midpoint) {
+                    this.midpoint = midpoint;
+                }
+
+                /**
+                 * Get the lowest index within the given range that satisfies the given test.
+                 *
+                 * @param collection the collection object (must not be {@code null})
+                 * @param from the low end of the range (inclusive)
+                 * @param to the high end of the range (exclusive)
+                 * @param keyExtractor the key extraction function (must not be {@code null})
+                 * @param keyTester the test for the key (must not be {@code null})
+                 * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the
+                 *         test within the range
+                 * @param <C> the collection type
+                 * @param <K> the key type
+                 */
+                public <C, K> long find(C collection, long from, long to, ObjLongFunction<C, K> keyExtractor,
+                        Predicate<K> keyTester) {
+                    return searchLong(from, to, collection, keyExtractor, keyTester, (Void) null, midpoint, ByKey::find0);
+                }
+
+                private static <C, K> boolean find0(long idx, C collection, ObjLongFunction<C, K> keyExtractor,
+                        Predicate<K> keyTester, Void ignored) {
+                    return keyTester.test(keyExtractor.apply(collection, idx));
+                }
+
+                /**
+                 * Get the lowest index within the given range that satisfies the given test for the search value.
+                 *
+                 * @param collection the collection object (must not be {@code null})
+                 * @param searchVal the value to search for
+                 * @param from the low end of the range (inclusive)
+                 * @param to the high end of the range (exclusive)
+                 * @param keyExtractor the key extraction function (must not be {@code null})
+                 * @param keyTester the test for the key (must not be {@code null})
+                 * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the
+                 *         test within the range
+                 * @param <C> the collection type
+                 * @param <K> the key type
+                 * @param <V> the value type
+                 */
+                public <C, K, V> long find(C collection, V searchVal, long from, long to, ObjLongFunction<C, K> keyExtractor,
+                        BiPredicate<V, K> keyTester) {
+                    return searchLong(from, to, collection, searchVal, keyExtractor, keyTester, midpoint, ByKey::find1);
+                }
+
+                private static <C, K, V> boolean find1(long idx, C collection, V searchVal, ObjLongFunction<C, K> keyExtractor,
+                        BiPredicate<V, K> keyTester) {
+                    return keyTester.test(searchVal, keyExtractor.apply(collection, idx));
+                }
+
+                /**
+                 * Get the lowest index within the given range whose key is equal to or greater than
+                 * the search key, according to the {@linkplain Comparator#naturalOrder() natural order} of
+                 * the search space.
+                 *
+                 * @param collection the collection object (must not be {@code null})
+                 * @param searchKey the key to search for (must not be {@code null})
+                 * @param from the low end of the range (inclusive)
+                 * @param to the high end of the range (exclusive)
+                 * @param keyExtractor the key extraction function (must not be {@code null})
+                 * @return the lowest index within the range which satisfies the condition, or {@code to} if no values satisfy
+                 *         the condition within the range
+                 * @param <C> the collection type
+                 * @param <K> the key type
+                 */
+                public <C, K extends Comparable<? super K>> long findFirst(C collection, K searchKey, long from, long to,
+                        ObjLongFunction<C, K> keyExtractor) {
+                    return findFirst(collection, searchKey, from, to, keyExtractor, Comparator.naturalOrder());
+                }
+
+                /**
+                 * Get the lowest index within the given range whose key is equal to or greater than
+                 * the search key, according to the given comparator.
+                 *
+                 * @param collection the collection object (must not be {@code null})
+                 * @param searchKey the key to search for (must not be {@code null})
+                 * @param from the low end of the range (inclusive)
+                 * @param to the high end of the range (exclusive)
+                 * @param keyExtractor the key extraction function (must not be {@code null})
+                 * @param cmp the comparator (must not be {@code null})
+                 * @return the lowest index within the range which satisfies the condition, or {@code to} if no values satisfy
+                 *         the condition within the range
+                 * @param <C> the collection type
+                 * @param <K> the key type
+                 */
+                public <C, K> long findFirst(C collection, K searchKey, long from, long to, ObjLongFunction<C, K> keyExtractor,
+                        Comparator<? super K> cmp) {
+                    return searchLong(from, to, collection, searchKey, keyExtractor, cmp, midpoint, ByKey::find2);
+                }
+
+                private static <C, K> boolean find2(long idx, C collection, K searchKey, ObjLongFunction<C, K> keyExtractor,
+                        Comparator<? super K> cmp) {
+                    return cmp.compare(searchKey, keyExtractor.apply(collection, idx)) >= 0;
+                }
+            }
+        }
+    }
+
+    /**
+     * Binary searches over a range of objects.
+     */
+    public static final class ObjRange {
+        private static final ObjRange instance = new ObjRange();
+
+        private ObjRange() {
+        }
+
+        /**
+         * Get the lowest index within the given range that satisfies the given test.
+         *
+         * @param from the low end of the range (inclusive)
+         * @param to the high end of the range (exclusive)
+         * @param midpoint the midpoint function (must not be {@code null})
+         * @param test the test (must not be {@code null})
+         * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the test
+         *         within the range
+         * @param <T> the index type
+         */
+        public <T> T find(T from, T to, BinaryOperator<T> midpoint, Predicate<T> test) {
+            return searchObject(from, to, test, (Void) null, (Void) null, (Void) null, midpoint, ObjRange::find0);
+        }
+
+        private static <T> boolean find0(T idx, Predicate<T> test, Void ignored0, Void ignored1, Void ignored2) {
+            return test.test(idx);
+        }
+
+        /**
+         * {@return search operations over a collection}
+         */
+        public static InCollection inCollection() {
+            return InCollection.instance;
+        }
+
+        /**
+         * Search operations within a collection.
+         */
+        public static final class InCollection {
+            private static final InCollection instance = new InCollection();
+
+            private InCollection() {
+            }
+
+            /**
+             * Get the lowest index within the given range that satisfies the given test.
+             *
+             * @param collection the collection object (must not be {@code null})
+             * @param from the low end of the range (inclusive)
+             * @param to the high end of the range (exclusive)
+             * @param midpoint the midpoint function (must not be {@code null})
+             * @param test the test (must not be {@code null})
+             * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the test
+             *         within the range
+             * @param <C> the collection type
+             * @param <T> the index type
+             */
+            public <T, C> T find(C collection, T from, T to, BinaryOperator<T> midpoint, BiPredicate<C, T> test) {
+                return searchObject(from, to, collection, test, (Void) null, (Void) null, midpoint, InCollection::find0);
+            }
+
+            private static <T, C> boolean find0(T idx, C collection, BiPredicate<C, T> test, Void ignored0, Void ignored1) {
+                return test.test(collection, idx);
+            }
+
+            /**
+             * {@return search operations which operate by an extracted key}
+             */
+            public ByKey byKey() {
+                return ByKey.instance;
+            }
+
+            /**
+             * Search operations within a collection which operate on an extracted key using a custom midpoint function.
+             */
+            public static final class ByKey {
+                private static final ByKey instance = new ByKey();
+
+                private ByKey() {
+                }
+
+                /**
+                 * Get the lowest index within the given range that satisfies the given test.
+                 *
+                 * @param collection the collection object (must not be {@code null})
+                 * @param from the low end of the range (inclusive)
+                 * @param to the high end of the range (exclusive)
+                 * @param midpoint the midpoint function (must not be {@code null})
+                 * @param keyExtractor the key extraction function (must not be {@code null})
+                 * @param test the test for the key (must not be {@code null})
+                 * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the
+                 *         test within the range
+                 * @param <T> the index type
+                 * @param <C> the collection type
+                 * @param <K> the key type
+                 */
+                public <T, C, K> T find(C collection, T from, T to, BinaryOperator<T> midpoint,
+                        BiFunction<C, T, K> keyExtractor,
+                        Predicate<K> test) {
+                    return searchObject(from, to, collection, keyExtractor, test, (Void) null, midpoint, ByKey::find0);
+                }
+
+                private static <T, C, K> boolean find0(T idx, C collection, BiFunction<C, T, K> keyExtractor, Predicate<K> test,
+                        Void ignored) {
+                    return test.test(keyExtractor.apply(collection, idx));
+                }
+
+                /**
+                 * Get the lowest index within the given range that satisfies the given test for the search value.
+                 *
+                 * @param collection the collection object (must not be {@code null})
+                 * @param searchVal the value to search for
+                 * @param from the low end of the range (inclusive)
+                 * @param to the high end of the range (exclusive)
+                 * @param midpoint the midpoint function (must not be {@code null})
+                 * @param keyExtractor the key extraction function (must not be {@code null})
+                 * @param keyTester the test for the key (must not be {@code null})
+                 * @return the lowest index within the range which satisfies the test, or {@code to} if no values satisfy the
+                 *         test within the range
+                 * @param <T> the index type
+                 * @param <C> the collection type
+                 * @param <K> the key type
+                 * @param <V> the value type
+                 */
+                public <T, C, K, V> T find(C collection, V searchVal, T from, T to, BinaryOperator<T> midpoint,
+                        BiFunction<C, T, K> keyExtractor,
+                        BiPredicate<V, K> keyTester) {
+                    return searchObject(from, to, collection, searchVal, keyExtractor, keyTester, midpoint, ByKey::find1);
+                }
+
+                private static <T, C, K, V> boolean find1(T idx, C collection, V searchVal, BiFunction<C, T, K> keyExtractor,
+                        BiPredicate<V, K> test) {
+                    return test.test(searchVal, keyExtractor.apply(collection, idx));
+                }
+
+                /**
+                 * Get the lowest index within the given range whose key is equal to or greater than
+                 * the search key, according to the {@linkplain Comparator#naturalOrder() natural order} of
+                 * the search space.
+                 *
+                 * @param collection the collection object (must not be {@code null})
+                 * @param searchKey the key to search for (must not be {@code null})
+                 * @param from the low end of the range (inclusive)
+                 * @param to the high end of the range (exclusive)
+                 * @param midpoint the midpoint function (must not be {@code null})
+                 * @param keyExtractor the key extraction function (must not be {@code null})
+                 * @return the lowest index within the range which satisfies the condition, or {@code to} if no values satisfy
+                 *         the condition within the range
+                 * @param <T> the index type
+                 * @param <C> the collection type
+                 * @param <K> the key type
+                 */
+                public <T, C, K extends Comparable<? super K>> T findFirst(C collection, K searchKey, T from, T to,
+                        BinaryOperator<T> midpoint, BiFunction<C, T, K> keyExtractor) {
+                    return findFirst(collection, searchKey, from, to, midpoint, keyExtractor, Comparator.naturalOrder());
+                }
+
+                /**
+                 * Get the lowest index within the given range whose key is equal to or greater than
+                 * the search key, according to the given comparator.
+                 *
+                 * @param collection the collection object (must not be {@code null})
+                 * @param searchKey the key to search for (must not be {@code null})
+                 * @param from the low end of the range (inclusive)
+                 * @param to the high end of the range (exclusive)
+                 * @param midpoint the midpoint function (must not be {@code null})
+                 * @param keyExtractor the key extraction function (must not be {@code null})
+                 * @param cmp the comparator (must not be {@code null})
+                 * @return the lowest index within the range which satisfies the condition, or {@code to} if no values satisfy
+                 *         the condition within the range
+                 * @param <T> the index type
+                 * @param <C> the collection type
+                 * @param <K> the key type
+                 */
+                public <T, C, K> T findFirst(C collection, K searchKey, T from, T to, BinaryOperator<T> midpoint,
+                        BiFunction<C, T, K> keyExtractor,
+                        Comparator<? super K> cmp) {
+                    return searchObject(from, to, collection, searchKey, keyExtractor, cmp, midpoint, ByKey::find2);
+                }
+
+                private static <T, C, K> boolean find2(T idx, C collection, K searchKey, BiFunction<C, T, K> keyExtractor,
+                        Comparator<? super K> cmp) {
+                    return cmp.compare(searchKey, keyExtractor.apply(collection, idx)) >= 0;
+                }
+            }
+        }
+    }
+
+    // midpoint functions
+
+    private static int signedMidpoint(int from, int to) {
+        return from + (to - from >> 1);
+    }
+
+    private static int unsignedMidpoint(int from, int to) {
+        return from + (to - from >>> 1);
+    }
+
+    private static long signedMidpoint(long from, long to) {
+        return from + (to - from >> 1);
+    }
+
+    private static long unsignedMidpoint(long from, long to) {
+        return from + (to - from >>> 1);
+    }
+
+    // Theoretically, we could use only the object variation and rely on box types, compiler magic and
+    // future value type support for performance. However, this is not yet a reality so we will have
+    // three versions for now: one that operates on object ranges, and two that operate on integer ranges (int/long).
+
+    private interface ObjIdxTestFunction<T, A, B, C, D> {
+        boolean test(T idx, A a, B b, C c, D d);
+    }
+
+    private static <T, A, B, C, D> T searchObject(T from, T to, A a, B b, C c, D d, BinaryOperator<T> midpoint,
+            ObjIdxTestFunction<T, A, B, C, D> test) {
+        T mid = midpoint.apply(from, to);
+        T newMid;
+        for (;;) {
+            if (test.test(mid, a, b, c, d)) {
+                to = mid;
+                newMid = midpoint.apply(from, to);
+                if (Objects.equals(mid, newMid)) {
+                    return from;
+                }
+            } else {
+                from = mid;
+                newMid = midpoint.apply(from, to);
+                if (Objects.equals(mid, newMid)) {
+                    return to;
+                }
+            }
+            mid = newMid;
+        }
+    }
+
+    private interface LongIdxTestFunction<A, B, C, D> {
+        boolean test(long idx, A a, B b, C c, D d);
+    }
+
+    private static <A, B, C, D> long searchLong(long from, long to, A a, B b, C c, D d, LongBinaryOperator midpoint,
+            LongIdxTestFunction<A, B, C, D> test) {
+        long mid = midpoint.applyAsLong(from, to);
+        long newMid;
+        for (;;) {
+            if (test.test(mid, a, b, c, d)) {
+                to = mid;
+                newMid = midpoint.applyAsLong(from, to);
+                if (mid == newMid) {
+                    return from;
+                }
+            } else {
+                from = mid;
+                newMid = midpoint.applyAsLong(from, to);
+                if (mid == newMid) {
+                    return to;
+                }
+            }
+            mid = newMid;
+        }
+    }
+
+    private interface IntIdxTestFunction<A, B, C, D> {
+        boolean test(int idx, A a, B b, C c, D d);
+    }
+
+    private static <A, B, C, D> int searchInt(int from, int to, A a, B b, C c, D d, IntBinaryOperator midpoint,
+            IntIdxTestFunction<A, B, C, D> test) {
+        int mid = midpoint.applyAsInt(from, to);
+        int newMid;
+        for (;;) {
+            if (test.test(mid, a, b, c, d)) {
+                to = mid;
+                newMid = midpoint.applyAsInt(from, to);
+                if (mid == newMid) {
+                    return from;
+                }
+            } else {
+                from = mid;
+                newMid = midpoint.applyAsInt(from, to);
+                if (mid == newMid) {
+                    return to;
+                }
+            }
+            mid = newMid;
+        }
+    }
+}

--- a/search/src/main/java/module-info.java
+++ b/search/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+/**
+ * Utilities for performing efficient searches.
+ */
+module io.smallrye.common.search {
+    requires transitive io.smallrye.common.function;
+
+    exports io.smallrye.common.search;
+}

--- a/search/src/test/java/io/smallrye/common/search/TestIntRange.java
+++ b/search/src/test/java/io/smallrye/common/search/TestIntRange.java
@@ -1,0 +1,69 @@
+package io.smallrye.common.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public final class TestIntRange {
+    public TestIntRange() {
+    }
+
+    private static final int MAX_INT_UNSIGNED = 0xffffffff; // == -1
+
+    @Test
+    public void testEmptyRange() {
+        assertEquals(1, BinarySearch.intRange().find(1, 1, i -> true));
+        assertEquals(10, BinarySearch.intRange().find(10, 10, i -> true));
+    }
+
+    @Test
+    public void testRange() {
+        assertEquals(0, BinarySearch.intRange().find(0, 10, i -> i >= -100));
+        assertEquals(0, BinarySearch.intRange().find(0, 10, i -> i >= 0));
+        assertEquals(1, BinarySearch.intRange().find(0, 10, i -> i > 0));
+        assertEquals(4, BinarySearch.intRange().find(0, 10, i -> i >= 4));
+        assertEquals(5, BinarySearch.intRange().find(0, 10, i -> i > 4));
+        assertEquals(5, BinarySearch.intRange().find(0, 10, i -> i >= 5));
+        assertEquals(6, BinarySearch.intRange().find(0, 10, i -> i > 5));
+        assertEquals(10, BinarySearch.intRange().find(0, 10, i -> i >= 10));
+        assertEquals(10, BinarySearch.intRange().find(0, 10, i -> false));
+        assertEquals(0, BinarySearch.intRange().find(0, 10, i -> true));
+        // signed-specific ranges
+        assertEquals(-10, BinarySearch.intRange().find(-10, 10, i -> true));
+    }
+
+    @Test
+    public void testRangeUnsigned() {
+        assertEquals(0, BinarySearch.intRange().unsigned().find(0, 10, i -> i >= 0));
+        assertEquals(1, BinarySearch.intRange().unsigned().find(0, 10, i -> i > 0));
+        assertEquals(4, BinarySearch.intRange().unsigned().find(0, 10, i -> i >= 4));
+        assertEquals(5, BinarySearch.intRange().unsigned().find(0, 10, i -> i > 4));
+        assertEquals(5, BinarySearch.intRange().unsigned().find(0, 10, i -> i >= 5));
+        assertEquals(6, BinarySearch.intRange().unsigned().find(0, 10, i -> i > 5));
+        assertEquals(10, BinarySearch.intRange().unsigned().find(0, 10, i -> i >= 10));
+        assertEquals(10, BinarySearch.intRange().unsigned().find(0, 10, i -> false));
+        assertEquals(0, BinarySearch.intRange().unsigned().find(0, 10, i -> true));
+        // unsigned-specific ranges
+        assertEquals(MAX_INT_UNSIGNED, BinarySearch.intRange().find(0, MAX_INT_UNSIGNED, i -> false));
+        assertEquals(0, BinarySearch.intRange().unsigned().find(0, MAX_INT_UNSIGNED, i -> true));
+        assertEquals(0x8000_0000, BinarySearch.intRange().unsigned().find(0, MAX_INT_UNSIGNED,
+                i -> Integer.compareUnsigned(i, 0x8000_0000) >= 0));
+    }
+
+    @Test
+    public void testBigRange() {
+        assertEquals(1025, BinarySearch.intRange().find(0, Integer.MAX_VALUE, i -> i >= 1025));
+        assertEquals(1026, BinarySearch.intRange().find(0, Integer.MAX_VALUE, i -> i >= 1026));
+        assertEquals(99210, BinarySearch.intRange().find(49203, 848392, i -> i >= 99210));
+        assertEquals(Integer.MAX_VALUE, BinarySearch.intRange().find(0, Integer.MAX_VALUE, i -> false));
+        assertEquals(0, BinarySearch.intRange().find(0, Integer.MAX_VALUE, i -> true));
+    }
+
+    @Test
+    public void testRevRange() {
+        assertEquals(5, BinarySearch.intRange().find(9, -1, i -> i < 5));
+        assertEquals(6, BinarySearch.intRange().find(9, -1, i -> i <= 5));
+        assertEquals(0, BinarySearch.intRange().find(9, -1, i -> i < 0));
+        assertEquals(1, BinarySearch.intRange().find(9, -1, i -> i <= 0));
+    }
+}

--- a/search/src/test/java/io/smallrye/common/search/TestLongRange.java
+++ b/search/src/test/java/io/smallrye/common/search/TestLongRange.java
@@ -1,0 +1,69 @@
+package io.smallrye.common.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public final class TestLongRange {
+    public TestLongRange() {
+    }
+
+    private static final long MAX_LONG_UNSIGNED = 0xffffffff_ffffffffL; // == -1L
+
+    @Test
+    public void testEmptyRange() {
+        assertEquals(1, BinarySearch.longRange().find(1, 1, i -> true));
+        assertEquals(10, BinarySearch.longRange().find(10, 10, i -> true));
+    }
+
+    @Test
+    public void testRange() {
+        assertEquals(0, BinarySearch.longRange().find(0, 10, i -> i >= -100));
+        assertEquals(0, BinarySearch.longRange().find(0, 10, i -> i >= 0));
+        assertEquals(1, BinarySearch.longRange().find(0, 10, i -> i > 0));
+        assertEquals(4, BinarySearch.longRange().find(0, 10, i -> i >= 4));
+        assertEquals(5, BinarySearch.longRange().find(0, 10, i -> i > 4));
+        assertEquals(5, BinarySearch.longRange().find(0, 10, i -> i >= 5));
+        assertEquals(6, BinarySearch.longRange().find(0, 10, i -> i > 5));
+        assertEquals(10, BinarySearch.longRange().find(0, 10, i -> i >= 10));
+        assertEquals(10, BinarySearch.longRange().find(0, 10, i -> false));
+        assertEquals(0, BinarySearch.longRange().find(0, 10, i -> true));
+        // signed-specific ranges
+        assertEquals(-10, BinarySearch.longRange().find(-10, 10, i -> true));
+    }
+
+    @Test
+    public void testRangeUnsigned() {
+        assertEquals(0, BinarySearch.longRange().unsigned().find(0, 10, i -> i >= 0));
+        assertEquals(1, BinarySearch.longRange().unsigned().find(0, 10, i -> i > 0));
+        assertEquals(4, BinarySearch.longRange().unsigned().find(0, 10, i -> i >= 4));
+        assertEquals(5, BinarySearch.longRange().unsigned().find(0, 10, i -> i > 4));
+        assertEquals(5, BinarySearch.longRange().unsigned().find(0, 10, i -> i >= 5));
+        assertEquals(6, BinarySearch.longRange().unsigned().find(0, 10, i -> i > 5));
+        assertEquals(10, BinarySearch.longRange().unsigned().find(0, 10, i -> i >= 10));
+        assertEquals(10, BinarySearch.longRange().unsigned().find(0, 10, i -> false));
+        assertEquals(0, BinarySearch.longRange().unsigned().find(0, 10, i -> true));
+        // unsigned-specific ranges
+        assertEquals(MAX_LONG_UNSIGNED, BinarySearch.longRange().find(0, MAX_LONG_UNSIGNED, i -> false));
+        assertEquals(0, BinarySearch.longRange().unsigned().find(0, MAX_LONG_UNSIGNED, i -> true));
+        assertEquals(0x8000_0000_0000_0000L, BinarySearch.longRange().unsigned().find(0, MAX_LONG_UNSIGNED,
+                i -> Long.compareUnsigned(i, 0x8000_0000_0000_0000L) >= 0));
+    }
+
+    @Test
+    public void testBigRange() {
+        assertEquals(1025, BinarySearch.longRange().find(0, Long.MAX_VALUE, i -> i >= 1025));
+        assertEquals(1026, BinarySearch.longRange().find(0, Long.MAX_VALUE, i -> i >= 1026));
+        assertEquals(99210, BinarySearch.longRange().find(49203, 848392, i -> i >= 99210));
+        assertEquals(Long.MAX_VALUE, BinarySearch.longRange().find(0, Long.MAX_VALUE, i -> false));
+        assertEquals(0, BinarySearch.longRange().find(0, Long.MAX_VALUE, i -> true));
+    }
+
+    @Test
+    public void testRevRange() {
+        assertEquals(5, BinarySearch.longRange().find(9, -1, i -> i < 5));
+        assertEquals(6, BinarySearch.longRange().find(9, -1, i -> i <= 5));
+        assertEquals(0, BinarySearch.longRange().find(9, -1, i -> i < 0));
+        assertEquals(1, BinarySearch.longRange().find(9, -1, i -> i <= 0));
+    }
+}

--- a/search/src/test/java/io/smallrye/common/search/TestObjRange.java
+++ b/search/src/test/java/io/smallrye/common/search/TestObjRange.java
@@ -1,0 +1,59 @@
+package io.smallrye.common.search;
+
+import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.TEN;
+import static java.math.BigInteger.ZERO;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.Test;
+
+public final class TestObjRange {
+    private static final BigInteger MINUS_100 = BigInteger.valueOf(-100);
+    private static final BigInteger MINUS_TEN = BigInteger.valueOf(-10);
+
+    private static final BigInteger FOUR = BigInteger.valueOf(4);
+    private static final BigInteger FIVE = BigInteger.valueOf(5);
+    private static final BigInteger SIX = BigInteger.valueOf(6);
+
+    public TestObjRange() {
+    }
+
+    private static BigInteger biMidPoint(BigInteger a, BigInteger b) {
+        return a.add(b.subtract(a).shiftRight(1));
+    }
+
+    @Test
+    public void testEmptyRange() {
+        assertEquals(ONE, BinarySearch.objRange().find(ONE, ONE, TestObjRange::biMidPoint, i -> true));
+    }
+
+    @Test
+    public void testRange() {
+        assertEquals(ZERO, BinarySearch.objRange().find(ZERO, TEN, TestObjRange::biMidPoint, i -> i.compareTo(MINUS_100) >= 0));
+        assertEquals(ZERO, BinarySearch.objRange().find(ZERO, TEN, TestObjRange::biMidPoint, i -> i.compareTo(ZERO) >= 0));
+        assertEquals(ONE, BinarySearch.objRange().find(ZERO, TEN, TestObjRange::biMidPoint, i -> i.compareTo(ZERO) > 0));
+        assertEquals(FOUR, BinarySearch.objRange().find(ZERO, TEN, TestObjRange::biMidPoint, i -> i.compareTo(FOUR) >= 0));
+        assertEquals(FIVE, BinarySearch.objRange().find(ZERO, TEN, TestObjRange::biMidPoint, i -> i.compareTo(FOUR) > 0));
+        assertEquals(FIVE, BinarySearch.objRange().find(ZERO, TEN, TestObjRange::biMidPoint, i -> i.compareTo(FIVE) >= 0));
+        assertEquals(SIX, BinarySearch.objRange().find(ZERO, TEN, TestObjRange::biMidPoint, i -> i.compareTo(FIVE) > 0));
+        assertEquals(TEN, BinarySearch.objRange().find(ZERO, TEN, TestObjRange::biMidPoint, i -> i.compareTo(TEN) >= 0));
+        assertEquals(TEN, BinarySearch.objRange().find(ZERO, TEN, TestObjRange::biMidPoint, i -> false));
+        assertEquals(ZERO, BinarySearch.objRange().find(ZERO, TEN, TestObjRange::biMidPoint, i -> true));
+        assertEquals(MINUS_TEN, BinarySearch.objRange().find(MINUS_TEN, TEN, TestObjRange::biMidPoint, i -> true));
+    }
+
+    @Test
+    public void testAlgorithm() {
+        BigInteger bigNumber = BigInteger.valueOf(307031012708191L);
+        BigInteger square = bigNumber.multiply(bigNumber);
+
+        // search between 0 and square for bigNumber
+        assertEquals(bigNumber, BinarySearch.objRange().find(
+                ZERO,
+                square,
+                TestObjRange::biMidPoint,
+                val -> val.multiply(val).compareTo(square) >= 0));
+    }
+}


### PR DESCRIPTION
Will update the summary/description once things are more finalized.

Design (short version):

* `BinarySearch.intRange().find(0, 100, n -> n >= 35)` - find the first integer in range `[0, 100)` which satisfies the predicate `n >= 35` (in this case, yields 35 after about 7 steps)
* `BinarySearch.longRange().find(1000L, 1000000L, n -> n >= 2048L)` - find the first long integer in range `[1000L, 1000000L)` which satisfies the predicate `n >= 2048L`

We also have `BinarySearch.intRange().unsigned()` which treats the range as unsigned integers (`0..0xFFFF_FFFF`), and `BinarySearch.longRange().unsigned()` which is equivalent for `long`.

There are also variations which allow you to provide your own midpoint function.

There are helpers to search ranges of things, for example, given:

```java
public record Item(String name, String address) {}
```

We can search a `List<Item> list` for the given `name` using a helper like this:

`int idx = BinarySearch.intRange().findFirst(list, "Fred", 0, list.size(), (l, i) -> l.get(i).name())`

Then `idx` will either contain the exact match, or the point into which the exact match would go.

See https://bugs.openjdk.org/browse/JDK-8326330 for the original inspiration of this flexible implementation.

I'm not super happy with the API ergonomics (the factory methods). But it seemed better than having one `BinarySearch` class with 50 or more methods called `find`. And the factory methods are all monomorphic and don't actually allocate anything, so the perf impact is expected to be minimal as these can be trivially inlined. But I'm open to other ideas in terms of API ergonomics and naming of classes.