### PR TITLE
Slightly reduce the startup cost of the modules used in Quarkus

### DIFF
--- a/ref/src/main/java/io/smallrye/common/ref/References.java
+++ b/ref/src/main/java/io/smallrye/common/ref/References.java
@@ -31,8 +31,12 @@ public final class References {
             if (isBuildTime()) {
                 // do nothing (class should be reinitialized)
             } else {
-                final PrivilegedAction<Void> action = () -> startThreadAction(1);
-                doPrivileged(action);
+                doPrivileged(new PrivilegedAction<Void>() {
+                    @Override
+                    public Void run() {
+                        return startThreadAction(1);
+                    }
+                });
             }
         }
 
@@ -46,7 +50,8 @@ public final class References {
 
         private static Void startThreadAction(int id) {
             final ReaperThread thr = new ReaperThread();
-            thr.setName("Reference Reaper #" + id);
+            // avoid + because of startup cost of StringConcatFactory
+            thr.setName("Reference Reaper #".concat(String.valueOf(id)));
             thr.setDaemon(true);
             thr.start();
             return null;


### PR DESCRIPTION
The flamegraph of the existing situation:


![logger-unpatched](https://github.com/user-attachments/assets/264c67ed-b8f4-47db-9941-2b746006c984)

 becomes:

![logger-patched](https://github.com/user-attachments/assets/1ad602aa-8608-4e8c-905c-f63ff414f4c9)
