### PR TITLE
update Jandex to 3.1.8

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -23,7 +23,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jboss.jandex</groupId>
+        <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <!-- Plugins -->
         <version.bridger>1.6.Final</version.bridger>
         <version.sundrio>0.200.3</version.sundrio>
-        <version.jandex-maven-plugin>1.2.3</version.jandex-maven-plugin>
+        <version.jandex>3.1.8</version.jandex>
 
         <!-- Dependencies -->
         <version.asm>9.8</version.asm>
@@ -141,9 +141,9 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.jboss.jandex</groupId>
+                    <groupId>io.smallrye</groupId>
                     <artifactId>jandex-maven-plugin</artifactId>
-                    <version>${version.jandex-maven-plugin}</version>
+                    <version>${version.jandex}</version>
                     <executions>
                         <execution>
                             <id>make-index</id>

--- a/vertx-context/pom.xml
+++ b/vertx-context/pom.xml
@@ -43,7 +43,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
             </plugin>
         </plugins>


### PR DESCRIPTION
I specifically chose Jandex 3.1 because Quarkus 3.8 is still on that version. Quarkus 3.15 is on Jandex 3.2, so that would also be an option, but the classes in this project are not very complex and no new features added in later Jandex versions would be useful.