### PR TITLE
Hide Windows batch argument escaping behind an option

### DIFF
--- a/process/src/main/java/io/smallrye/common/process/ArgumentRule.java
+++ b/process/src/main/java/io/smallrye/common/process/ArgumentRule.java
@@ -14,7 +14,8 @@ enum ArgumentRule {
             // no operation (accepts any)
         }
 
-        List<String> formatArguments(final Path command, final List<String> arguments) throws IllegalArgumentException {
+        List<String> formatArguments(final Path command, final List<String> arguments, final boolean specialQuoting)
+                throws IllegalArgumentException {
             return Stream.concat(Stream.of(command.toString()), arguments.stream()).toList();
         }
     },
@@ -42,13 +43,19 @@ enum ArgumentRule {
             }
         }
 
-        List<String> formatArguments(final Path command, final List<String> arguments) throws IllegalArgumentException {
+        List<String> formatArguments(final Path command, final List<String> arguments, final boolean specialQuoting)
+                throws IllegalArgumentException {
             // in the future, this will be replaced with a variation which has extra quoting capabilities
             ArrayList<String> list = new ArrayList<>(arguments.size() + 5);
-            StringBuilder sb = new StringBuilder();
-            list.add(quote(command.toString(), sb));
-            for (final String argument : arguments) {
-                list.add(quote(argument, sb));
+            if (specialQuoting) {
+                StringBuilder sb = new StringBuilder();
+                list.add(quote(command.toString(), sb));
+                for (final String argument : arguments) {
+                    list.add(quote(argument, sb));
+                }
+            } else {
+                list.add(command.toString());
+                list.addAll(arguments);
             }
             return list;
         }
@@ -89,7 +96,8 @@ enum ArgumentRule {
             // OK
         }
 
-        List<String> formatArguments(final Path command, final List<String> arguments) throws IllegalArgumentException {
+        List<String> formatArguments(final Path command, final List<String> arguments, final boolean specialQuoting)
+                throws IllegalArgumentException {
             return Stream.concat(
                     Stream.of("powershell.exe", "-ExecutionPolicy", "Bypass", "-File", command.toString()),
                     arguments.stream()).toList();
@@ -103,5 +111,6 @@ enum ArgumentRule {
 
     abstract void checkArguments(List<String> arguments) throws IllegalArgumentException;
 
-    abstract List<String> formatArguments(Path command, List<String> arguments) throws IllegalArgumentException;
+    abstract List<String> formatArguments(Path command, List<String> arguments, boolean specialQuoting)
+            throws IllegalArgumentException;
 }

--- a/process/src/main/java/io/smallrye/common/process/PipelineBuilder.java
+++ b/process/src/main/java/io/smallrye/common/process/PipelineBuilder.java
@@ -45,6 +45,16 @@ public sealed interface PipelineBuilder<O> permits PipelineBuilder.Error, Pipeli
     PipelineBuilder<O> arguments(String... command);
 
     /**
+     * Enable special quoting for batch scripts on Windows.
+     * Note that this requires the batch script to use a specific form
+     * of argument expansion.
+     *
+     * @param specialQuoting {@code true} to enable special quoting, or {@code false} to use default quoting
+     * @return this builder
+     */
+    PipelineBuilder<O> specialQuoting(boolean specialQuoting);
+
+    /**
      * Set the working directory for this process execution.
      *
      * @param directory the working directory (must not be {@code null})

--- a/process/src/main/java/io/smallrye/common/process/PipelineRunner.java
+++ b/process/src/main/java/io/smallrye/common/process/PipelineRunner.java
@@ -597,7 +597,8 @@ class PipelineRunner<O> {
     int createThreads(final ThreadFactory tf, final ProcessRunner<O> runner, final PipelineRunner<O> nextRunner)
             throws IOException {
         pb = processBuilder.pb;
-        pb.command(processBuilder.argumentRule.formatArguments(processBuilder.command, processBuilder.arguments));
+        pb.command(processBuilder.argumentRule.formatArguments(processBuilder.command, processBuilder.arguments,
+                processBuilder.specialQuoting));
         pb.directory(processBuilder.directory);
         int cnt = createInputThread(tf, runner)
                 + createErrorThreads(tf, runner)

--- a/process/src/main/java/io/smallrye/common/process/ProcessBuilder.java
+++ b/process/src/main/java/io/smallrye/common/process/ProcessBuilder.java
@@ -348,6 +348,9 @@ public sealed interface ProcessBuilder<O>
     }
 
     @Override
+    ProcessBuilder<O> specialQuoting(boolean specialQuoting);
+
+    @Override
     ProcessBuilder<O> directory(Path directory);
 
     @Override

--- a/process/src/main/java/io/smallrye/common/process/ProcessBuilderImpl.java
+++ b/process/src/main/java/io/smallrye/common/process/ProcessBuilderImpl.java
@@ -57,6 +57,7 @@ final class ProcessBuilderImpl<O> implements ProcessBuilder<O> {
     final Path command;
     final ArgumentRule argumentRule;
     File directory;
+    boolean specialQuoting;
     private volatile boolean locked;
     List<String> arguments = List.of();
     IntPredicate exitCodeChecker = e -> e == 0;
@@ -117,6 +118,11 @@ final class ProcessBuilderImpl<O> implements ProcessBuilder<O> {
         check();
         argumentRule.checkArguments(arguments);
         this.arguments = List.copyOf(arguments);
+        return this;
+    }
+
+    public ProcessBuilder<O> specialQuoting(final boolean specialQuoting) {
+        this.specialQuoting = specialQuoting;
         return this;
     }
 
@@ -232,6 +238,10 @@ final class ProcessBuilderImpl<O> implements ProcessBuilder<O> {
     public abstract sealed class ViewImpl implements ProcessBuilder<O> {
         public ProcessBuilder<O> arguments(final List<String> command) {
             return ProcessBuilderImpl.this.arguments(command);
+        }
+
+        public ProcessBuilder<O> specialQuoting(final boolean specialQuoting) {
+            return ProcessBuilderImpl.this.specialQuoting(specialQuoting);
         }
 
         public ProcessBuilder<O> directory(final Path directory) {

--- a/process/src/test/java/io/smallrye/common/process/WindowsSpecificTests.java
+++ b/process/src/test/java/io/smallrye/common/process/WindowsSpecificTests.java
@@ -33,18 +33,34 @@ public class WindowsSpecificTests {
         assertEquals(List.of("hello", "world"), output);
 
         output = ProcessBuilder.newBuilder(findScript("batch/echo_2_args.cmd"))
+                .specialQuoting(true)
+                .arguments("--foo=bar", "--foo bar")
+                .output().toStringList(16, 1024)
+                .run();
+        assertEquals(List.of("--foo=bar", "--foo bar"), output);
+
+        output = ProcessBuilder.newBuilder(findScript("batch/echo_2_args.cmd"))
+                .arguments("--foo=bar", "--foo bar")
+                .output().toStringList(16, 1024)
+                .run();
+        assertEquals(List.of("--foo", "bar"), output);
+
+        output = ProcessBuilder.newBuilder(findScript("batch/echo_2_args.cmd"))
+                .specialQuoting(true)
                 .arguments("with spaces", "with ^ caret")
                 .output().toStringList(16, 1024)
                 .run();
         assertEquals(List.of("with spaces", "with ^ caret"), output);
 
         output = ProcessBuilder.newBuilder(findScript("batch/echo_2_args.cmd"))
+                .specialQuoting(true)
                 .arguments("\"withQuotes\"", "\"quotes and spaces\"")
                 .output().toStringList(16, 1024)
                 .run();
         assertEquals(List.of("withQuotes", "quotes and spaces"), output);
 
         output = ProcessBuilder.newBuilder(findScript("batch/echo_2_args.cmd"))
+                .specialQuoting(true)
                 .arguments("\"with \"interior\" quotes\"", "it works!")
                 .output().toStringList(16, 1024)
                 .run();


### PR DESCRIPTION
There are two wrong ways to do it; this way the user can pick their poison.