### PR TITLE
Do not require `org.jboss.logging.annotations` at run time

### DIFF
--- a/process/src/main/java/module-info.java
+++ b/process/src/main/java/module-info.java
@@ -9,6 +9,6 @@ module io.smallrye.common.process {
     requires io.smallrye.common.constraint;
     requires io.smallrye.common.function;
     requires io.smallrye.common.os;
-    requires org.jboss.logging.annotations;
+    requires static org.jboss.logging.annotations;
     requires org.jboss.logging;
 }


### PR DESCRIPTION
Fixes #458