### PR TITLE
Introduce secure copy, recursive copy, and move functionality

### DIFF
--- a/io/src/main/java/io/smallrye/common/io/Files2.java
+++ b/io/src/main/java/io/smallrye/common/io/Files2.java
@@ -1,11 +1,20 @@
 package io.smallrye.common.io;
 
+import static io.smallrye.common.constraint.Assert.checkNotNullArrayParam;
 import static io.smallrye.common.constraint.Assert.checkNotNullParam;
+import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
 import static io.smallrye.common.io.Messages.log;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteOrder;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.CopyOption;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -15,9 +24,19 @@ import java.nio.file.NotDirectoryException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.SecureDirectoryStream;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.DosFileAttributeView;
+import java.nio.file.attribute.DosFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -419,6 +438,794 @@ public final class Files2 {
     }
 
     /**
+     * Copy from one channel to another in the most efficient manner supported by the JDK.
+     * Neither channel is closed.
+     *
+     * @param in the input channel (must not be {@code null})
+     * @param out the output channel (must not be {@code null})
+     * @return the number of bytes copied
+     * @throws IOException if copying failed for some reason
+     */
+    public static long copy(ReadableByteChannel in, WritableByteChannel out) throws IOException {
+        checkNotNullParam("in", in);
+        checkNotNullParam("out", out);
+        if (in instanceof FileChannel fc) {
+            // zero-copy from source
+            long size = fc.size();
+            long cnt = 0;
+            while (cnt < size) {
+                long res = fc.transferTo(cnt, size - cnt, out);
+                if (res == 0) {
+                    throw log.partialCopy(fc, out, size, cnt);
+                }
+                cnt += res;
+            }
+            return cnt;
+        } else if (in instanceof SeekableByteChannel sc && out instanceof FileChannel fc) {
+            // zero-copy to dest
+            long size = sc.size();
+            long cnt = 0;
+            while (cnt < size) {
+                long res = fc.transferFrom(sc, cnt, size - cnt);
+                if (res == 0) {
+                    throw log.partialCopy(fc, out, size, cnt);
+                }
+                cnt += res;
+            }
+            return cnt;
+        } else {
+            // no zero-copy channel API, so try the zero-copy stream API instead
+            return Channels.newInputStream(in).transferTo(Channels.newOutputStream(out));
+        }
+    }
+
+    /**
+     * Equivalent to calling {@link #copy(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)} with no
+     * options.
+     *
+     * @param sourceDir the directory stream of the source directory (must not be {@code null})
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destDir the directory stream of the destination directory (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @throws UnsupportedOperationException if the combination of options is unsupported by the source or destination
+     *         filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copy(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)
+     */
+    public static void copy(SecureDirectoryStream<Path> sourceDir, Path srcFile, SecureDirectoryStream<Path> destDir,
+            Path destFile) throws IOException {
+        copyOrMove(sourceDir, srcFile, destDir, destFile, 0);
+    }
+
+    /**
+     * Equivalent to calling {@link #copy(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)} with one
+     * option.
+     *
+     * @param sourceDir the directory stream of the source directory (must not be {@code null})
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destDir the directory stream of the destination directory (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param option1 the copy option to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if the combination of options is unsupported by the source or destination
+     *         filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copy(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)
+     */
+    public static void copy(SecureDirectoryStream<Path> sourceDir, Path srcFile, SecureDirectoryStream<Path> destDir,
+            Path destFile, CopyOption option1) throws IOException {
+        checkNotNullParam("option1", option1);
+        copyOrMove(sourceDir, srcFile, destDir, destFile, parseCopyOption(option1));
+    }
+
+    /**
+     * Equivalent to calling {@link #copy(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)} with two
+     * options.
+     *
+     * @param sourceDir the directory stream of the source directory (must not be {@code null})
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destDir the directory stream of the destination directory (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param option1 the first copy option to use for the operation (must not be {@code null})
+     * @param option2 the second copy option to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if the combination of options is unsupported by the source or destination
+     *         filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copy(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)
+     */
+    public static void copy(SecureDirectoryStream<Path> sourceDir, Path srcFile, SecureDirectoryStream<Path> destDir,
+            Path destFile, CopyOption option1, CopyOption option2) throws IOException {
+        checkNotNullParam("option1", option1);
+        checkNotNullParam("option2", option2);
+        copyOrMove(sourceDir, srcFile, destDir, destFile, parseCopyOption(option1) | parseCopyOption(option2));
+    }
+
+    /**
+     * Copy a file as securely as possible from one directory and path to another.
+     * If both {@code srcFile} and {@code destFile} are {@linkplain Path#isAbsolute() absolute paths},
+     * then this method behaves exactly the same as {@link Files#copy(Path, Path, CopyOption...)}.
+     * If {@code srcFile} and {@code destFile} are found to refer to the same file, then no action is taken
+     * and this method will return directly.
+     * <p>
+     * Otherwise, an attempt is made to:
+     * <ul>
+     * <li>Copy symbolic links as symbolic links (when {@link LinkOption#NOFOLLOW_LINKS} is given)</li>
+     * <li>Copy directories as directories (non-recursively)</li>
+     * <li>Preserve file attributes (when {@link StandardCopyOption#COPY_ATTRIBUTES} is given)</li>
+     * <li>Copy regular files using the most efficient JDK mechanism available</li>
+     * </ul>
+     * The operation may fail with a {@link IOException} if some part of the operation fails; in this case,
+     * the file may be partially copied.
+     * <p>
+     * If some aspect of the operation is not supported, {@link UnsupportedOperationException} will be thrown.
+     * Currently, the currently unsupported operations include:
+     * <ul>
+     * <li>Copying a symbolic link from or to a relative path (unsupported by the JDK as of JDK 25)</li>
+     * <li>Copying a directory into a relative path (unsupported by the JDK as of JDK 25)</li>
+     * </ul>
+     * The following copy options are allowed:
+     * <ul>
+     * <li>{@link LinkOption#NOFOLLOW_LINKS}</li>
+     * <li>{@link StandardCopyOption#COPY_ATTRIBUTES}</li>
+     * <li>{@link StandardCopyOption#REPLACE_EXISTING}</li>
+     * </ul>
+     * Giving any other option will cause a {@link IllegalArgumentException} to be thrown.
+     *
+     * @param sourceDir the directory stream of the source directory (must not be {@code null})
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destDir the directory stream of the destination directory (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param options the copy options to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if the combination of options is unsupported by the source or destination
+     *         filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see SecureDirectoryStream#move(Object, SecureDirectoryStream, Object)
+     */
+    public static void copy(SecureDirectoryStream<Path> sourceDir, Path srcFile, SecureDirectoryStream<Path> destDir,
+            Path destFile, CopyOption... options) throws IOException {
+        copyOrMove(sourceDir, srcFile, destDir, destFile, parseCopyOptions(options));
+    }
+
+    /**
+     * Copy a file, even if secure directory streams are not supported.
+     * <em>Warning:</em> this method can potentially copy files outside the intended path
+     * if the target platform does not support secure directory iteration.
+     *
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copy(Path, Path)
+     */
+    public static void copyEvenIfInsecure(Path srcFile, Path destFile) throws IOException {
+        checkNotNullParam("srcFile", srcFile);
+        checkNotNullParam("destFile", destFile);
+        SecureDirectoryStream<Path> base = CWD_SDS;
+        if (base != null) {
+            // secure!
+            copy(base, srcFile, base, destFile);
+        } else {
+            copyInsecurely(srcFile, destFile);
+        }
+    }
+
+    /**
+     * Equivalent to calling {@link #copy(Path, Path, CopyOption...)} with no options.
+     *
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @throws UnsupportedOperationException if secure directory traversal is unsupported or if the combination of options is
+     *         unsupported by the source or destination filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copy(Path, Path, CopyOption...)
+     */
+    public static void copy(Path srcFile, Path destFile) throws IOException {
+        checkNotNullParam("srcFile", srcFile);
+        checkNotNullParam("destFile", destFile);
+        SecureDirectoryStream<Path> base = CWD_SDS;
+        if (base == null) {
+            throw Messages.log.secureDirectoryNotSupported(srcFile.getFileSystem(), srcFile);
+        }
+        copy(base, srcFile, base, destFile);
+    }
+
+    /**
+     * Equivalent to calling {@link #copy(Path, Path, CopyOption...)} with one option.
+     *
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param option1 the copy option to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if secure directory traversal is unsupported or if the combination of options is
+     *         unsupported by the source or destination filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copy(Path, Path, CopyOption...)
+     */
+    public static void copy(Path srcFile, Path destFile, CopyOption option1) throws IOException {
+        checkNotNullParam("srcFile", srcFile);
+        checkNotNullParam("destFile", destFile);
+        SecureDirectoryStream<Path> base = CWD_SDS;
+        if (base == null) {
+            throw Messages.log.secureDirectoryNotSupported(srcFile.getFileSystem(), srcFile);
+        }
+        copy(base, srcFile, base, destFile, option1);
+    }
+
+    /**
+     * Equivalent to calling {@link #copy(Path, Path, CopyOption...)} with two options.
+     *
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param option1 the first copy option to use for the operation (must not be {@code null})
+     * @param option2 the second copy option to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if secure directory traversal is unsupported or if the combination of options is
+     *         unsupported by the source or destination filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copy(Path, Path, CopyOption...)
+     */
+    public static void copy(Path srcFile, Path destFile, CopyOption option1, CopyOption option2) throws IOException {
+        checkNotNullParam("srcFile", srcFile);
+        checkNotNullParam("destFile", destFile);
+        SecureDirectoryStream<Path> base = CWD_SDS;
+        if (base == null) {
+            throw Messages.log.secureDirectoryNotSupported(srcFile.getFileSystem(), srcFile);
+        }
+        copy(base, srcFile, base, destFile, option1, option2);
+    }
+
+    /**
+     * Copy a file as securely as possible from one path to another.
+     * This method uses a secure directory stream acquired from the current working directory
+     * to perform the operation.
+     * If {@code srcFile} and {@code destFile} are found to refer to the same file, then no action is taken
+     * and this method will return directly.
+     * <p>
+     * Otherwise, an attempt is made to:
+     * <ul>
+     * <li>Copy symbolic links as symbolic links (when {@link LinkOption#NOFOLLOW_LINKS} is given)</li>
+     * <li>Copy directories as directories (non-recursively)</li>
+     * <li>Preserve file attributes (when {@link StandardCopyOption#COPY_ATTRIBUTES} is given)</li>
+     * <li>Copy regular files using the most efficient JDK mechanism available</li>
+     * </ul>
+     * The operation may fail with a {@link IOException} if some part of the operation fails; in this case,
+     * the file may be partially copied.
+     * <p>
+     * If some aspect of the operation is not supported, {@link UnsupportedOperationException} will be thrown.
+     * Currently, the currently unsupported operations include:
+     * <ul>
+     * <li>Copying a symbolic link from or to a relative path (unsupported by the JDK as of JDK 25)</li>
+     * <li>Copying a directory into a relative path (unsupported by the JDK as of JDK 25)</li>
+     * </ul>
+     * The following copy options are allowed:
+     * <ul>
+     * <li>{@link LinkOption#NOFOLLOW_LINKS}</li>
+     * <li>{@link StandardCopyOption#COPY_ATTRIBUTES}</li>
+     * <li>{@link StandardCopyOption#REPLACE_EXISTING}</li>
+     * </ul>
+     * Giving any other option will cause a {@link IllegalArgumentException} to be thrown.
+     *
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param options the copy options to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if secure directory traversal is unsupported or if the combination of options is
+     *         unsupported by the source or destination filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copy(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)
+     */
+    public static void copy(Path srcFile, Path destFile, CopyOption... options) throws IOException {
+        checkNotNullParam("srcFile", srcFile);
+        checkNotNullParam("destFile", destFile);
+        SecureDirectoryStream<Path> base = CWD_SDS;
+        if (base == null) {
+            throw Messages.log.secureDirectoryNotSupported(srcFile.getFileSystem(), srcFile);
+        }
+        copy(base, srcFile, base, destFile, options);
+    }
+
+    /**
+     * Equivalent to calling {@link #copyRecursively(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)}
+     * with no options.
+     *
+     * @param sourceDir the directory stream of the source directory (must not be {@code null})
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destDir the directory stream of the destination directory (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @throws UnsupportedOperationException if the combination of options is unsupported by the source or destination
+     *         filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copyRecursively(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)
+     */
+    public static void copyRecursively(SecureDirectoryStream<Path> sourceDir, Path srcFile, SecureDirectoryStream<Path> destDir,
+            Path destFile) throws IOException {
+        copyOrMove(sourceDir, srcFile, destDir, destFile, OPT_RECURSIVE);
+    }
+
+    /**
+     * Equivalent to calling {@link #copyRecursively(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)}
+     * with one option.
+     *
+     * @param sourceDir the directory stream of the source directory (must not be {@code null})
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destDir the directory stream of the destination directory (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param option1 the copy option to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if the combination of options is unsupported by the source or destination
+     *         filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copyRecursively(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)
+     */
+    public static void copyRecursively(SecureDirectoryStream<Path> sourceDir, Path srcFile, SecureDirectoryStream<Path> destDir,
+            Path destFile, CopyOption option1) throws IOException {
+        checkNotNullParam("option1", option1);
+        copyOrMove(sourceDir, srcFile, destDir, destFile, parseCopyOption(option1) | OPT_RECURSIVE);
+    }
+
+    /**
+     * Equivalent to calling {@link #copyRecursively(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)}
+     * with two options.
+     *
+     * @param sourceDir the directory stream of the source directory (must not be {@code null})
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destDir the directory stream of the destination directory (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param option1 the first copy option to use for the operation (must not be {@code null})
+     * @param option2 the second copy option to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if the combination of options is unsupported by the source or destination
+     *         filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copyRecursively(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)
+     */
+    public static void copyRecursively(SecureDirectoryStream<Path> sourceDir, Path srcFile, SecureDirectoryStream<Path> destDir,
+            Path destFile, CopyOption option1, CopyOption option2) throws IOException {
+        checkNotNullParam("option1", option1);
+        checkNotNullParam("option2", option2);
+        copyOrMove(sourceDir, srcFile, destDir, destFile, parseCopyOption(option1) | parseCopyOption(option2) | OPT_RECURSIVE);
+    }
+
+    /**
+     * Recursively copy a file or directory as securely as possible from one directory and path to another.
+     * If {@code srcFile} and {@code destFile} are found to refer to the same file, then no action is taken
+     * and this method will return directly.
+     * <p>
+     * Otherwise, an attempt is made to:
+     * <ul>
+     * <li>Copy symbolic links as symbolic links (when {@link LinkOption#NOFOLLOW_LINKS} is given)</li>
+     * <li>Copy directories as directories (recursively)</li>
+     * <li>Preserve file attributes (when {@link StandardCopyOption#COPY_ATTRIBUTES} is given)</li>
+     * <li>Copy regular files using the most efficient JDK mechanism available</li>
+     * </ul>
+     * The operation may fail with a {@link IOException} if some part of the operation fails; in this case,
+     * the file or directory may be partially copied.
+     * <p>
+     * If some aspect of the operation is not supported, {@link UnsupportedOperationException} will be thrown.
+     * Currently, the currently unsupported operations include:
+     * <ul>
+     * <li>Copying a symbolic link from or to a relative path (unsupported by the JDK as of JDK 25)</li>
+     * <li>Copying a directory into a relative path (unsupported by the JDK as of JDK 25)</li>
+     * </ul>
+     * The following copy options are allowed:
+     * <ul>
+     * <li>{@link LinkOption#NOFOLLOW_LINKS}</li>
+     * <li>{@link StandardCopyOption#COPY_ATTRIBUTES}</li>
+     * <li>{@link StandardCopyOption#REPLACE_EXISTING}</li>
+     * </ul>
+     * Giving any other option will cause a {@link IllegalArgumentException} to be thrown.
+     *
+     * @param sourceDir the directory stream of the source directory (must not be {@code null})
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destDir the directory stream of the destination directory (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param options the copy options to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if the combination of options is unsupported by the source or destination
+     *         filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     */
+    public static void copyRecursively(SecureDirectoryStream<Path> sourceDir, Path srcFile, SecureDirectoryStream<Path> destDir,
+            Path destFile, CopyOption... options) throws IOException {
+        copyOrMove(sourceDir, srcFile, destDir, destFile, parseCopyOptions(options) | OPT_RECURSIVE);
+    }
+
+    /**
+     * Recursively copy a file or directory, even if secure directory streams are not supported.
+     * <em>Warning:</em> this method can potentially copy files outside the intended path
+     * if the target platform does not support secure directory iteration.
+     *
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copyRecursively(Path, Path)
+     */
+    public static void copyRecursivelyEvenIfInsecure(Path srcFile, Path destFile) throws IOException {
+        checkNotNullParam("srcFile", srcFile);
+        checkNotNullParam("destFile", destFile);
+        SecureDirectoryStream<Path> base = CWD_SDS;
+        if (base != null) {
+            // secure!
+            copyRecursively(base, srcFile, base, destFile);
+        } else {
+            copyRecursivelyInsecurely(srcFile, destFile);
+        }
+    }
+
+    /**
+     * Equivalent to calling {@link #copyRecursively(Path, Path, CopyOption...)} with no options.
+     *
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @throws UnsupportedOperationException if secure directory traversal is unsupported or if the combination of options is
+     *         unsupported by the source or destination filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copyRecursively(Path, Path, CopyOption...)
+     */
+    public static void copyRecursively(Path srcFile, Path destFile) throws IOException {
+        checkNotNullParam("srcFile", srcFile);
+        checkNotNullParam("destFile", destFile);
+        SecureDirectoryStream<Path> base = CWD_SDS;
+        if (base == null) {
+            throw Messages.log.secureDirectoryNotSupported(srcFile.getFileSystem(), srcFile);
+        }
+        copyRecursively(base, srcFile, base, destFile);
+    }
+
+    /**
+     * Equivalent to calling {@link #copyRecursively(Path, Path, CopyOption...)} with one option.
+     *
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param option1 the copy option to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if secure directory traversal is unsupported or if the combination of options is
+     *         unsupported by the source or destination filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copyRecursively(Path, Path, CopyOption...)
+     */
+    public static void copyRecursively(Path srcFile, Path destFile, CopyOption option1) throws IOException {
+        checkNotNullParam("srcFile", srcFile);
+        checkNotNullParam("destFile", destFile);
+        SecureDirectoryStream<Path> base = CWD_SDS;
+        if (base == null) {
+            throw Messages.log.secureDirectoryNotSupported(srcFile.getFileSystem(), srcFile);
+        }
+        copyRecursively(base, srcFile, base, destFile, option1);
+    }
+
+    /**
+     * Equivalent to calling {@link #copyRecursively(Path, Path, CopyOption...)} with two options.
+     *
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param option1 the first copy option to use for the operation (must not be {@code null})
+     * @param option2 the second copy option to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if secure directory traversal is unsupported or if the combination of options is
+     *         unsupported by the source or destination filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copyRecursively(Path, Path, CopyOption...)
+     */
+    public static void copyRecursively(Path srcFile, Path destFile, CopyOption option1, CopyOption option2) throws IOException {
+        checkNotNullParam("srcFile", srcFile);
+        checkNotNullParam("destFile", destFile);
+        SecureDirectoryStream<Path> base = CWD_SDS;
+        if (base == null) {
+            throw Messages.log.secureDirectoryNotSupported(srcFile.getFileSystem(), srcFile);
+        }
+        copyRecursively(base, srcFile, base, destFile, option1, option2);
+    }
+
+    /**
+     * Recursively copy a file or directory as securely as possible from one path to another.
+     * This method uses a secure directory stream acquired from the current working directory
+     * to perform the operation.
+     * If {@code srcFile} and {@code destFile} are found to refer to the same file, then no action is taken
+     * and this method will return directly.
+     * <p>
+     * Otherwise, an attempt is made to:
+     * <ul>
+     * <li>Copy symbolic links as symbolic links (when {@link LinkOption#NOFOLLOW_LINKS} is given)</li>
+     * <li>Copy directories as directories (recursively)</li>
+     * <li>Preserve file attributes (when {@link StandardCopyOption#COPY_ATTRIBUTES} is given)</li>
+     * <li>Copy regular files using the most efficient JDK mechanism available</li>
+     * </ul>
+     * The operation may fail with a {@link IOException} if some part of the operation fails; in this case,
+     * the file or directory may be partially copied.
+     * <p>
+     * If some aspect of the operation is not supported, {@link UnsupportedOperationException} will be thrown.
+     * Currently, the currently unsupported operations include:
+     * <ul>
+     * <li>Copying a symbolic link from or to a relative path (unsupported by the JDK as of JDK 25)</li>
+     * <li>Copying a directory into a relative path (unsupported by the JDK as of JDK 25)</li>
+     * </ul>
+     * The following copy options are allowed:
+     * <ul>
+     * <li>{@link LinkOption#NOFOLLOW_LINKS}</li>
+     * <li>{@link StandardCopyOption#COPY_ATTRIBUTES}</li>
+     * <li>{@link StandardCopyOption#REPLACE_EXISTING}</li>
+     * </ul>
+     * Giving any other option will cause a {@link IllegalArgumentException} to be thrown.
+     *
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param options the copy options to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if secure directory traversal is unsupported or if the combination of options is
+     *         unsupported by the source or destination filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during copy
+     *
+     * @see #copyRecursively(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)
+     */
+    public static void copyRecursively(Path srcFile, Path destFile, CopyOption... options) throws IOException {
+        checkNotNullParam("srcFile", srcFile);
+        checkNotNullParam("destFile", destFile);
+        SecureDirectoryStream<Path> base = CWD_SDS;
+        if (base == null) {
+            throw Messages.log.secureDirectoryNotSupported(srcFile.getFileSystem(), srcFile);
+        }
+        copyRecursively(base, srcFile, base, destFile, options);
+    }
+
+    /**
+     * Equivalent to calling {@link #move(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)} with no
+     * options.
+     *
+     * @param sourceDir the directory stream of the source directory (must not be {@code null})
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destDir the directory stream of the destination directory (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @throws UnsupportedOperationException if the combination of options is unsupported by the source or destination
+     *         filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during move
+     *
+     * @see #move(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)
+     */
+    public static void move(SecureDirectoryStream<Path> sourceDir, Path srcFile, SecureDirectoryStream<Path> destDir,
+            Path destFile) throws IOException {
+        copyOrMove(sourceDir, srcFile, destDir, destFile, OPT_MOVE | OPT_RECURSIVE);
+    }
+
+    /**
+     * Equivalent to calling {@link #move(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)} with one
+     * option.
+     *
+     * @param sourceDir the directory stream of the source directory (must not be {@code null})
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destDir the directory stream of the destination directory (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param option1 the move option to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if the combination of options is unsupported by the source or destination
+     *         filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during move
+     *
+     * @see #move(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)
+     */
+    public static void move(SecureDirectoryStream<Path> sourceDir, Path srcFile, SecureDirectoryStream<Path> destDir,
+            Path destFile, CopyOption option1) throws IOException {
+        checkNotNullParam("option1", option1);
+        copyOrMove(sourceDir, srcFile, destDir, destFile, parseCopyOption(option1) | OPT_MOVE | OPT_RECURSIVE);
+    }
+
+    /**
+     * Equivalent to calling {@link #move(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)} with two
+     * options.
+     *
+     * @param sourceDir the directory stream of the source directory (must not be {@code null})
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destDir the directory stream of the destination directory (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param option1 the first move option to use for the operation (must not be {@code null})
+     * @param option2 the second move option to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if the combination of options is unsupported by the source or destination
+     *         filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during move
+     *
+     * @see #move(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)
+     */
+    public static void move(SecureDirectoryStream<Path> sourceDir, Path srcFile, SecureDirectoryStream<Path> destDir,
+            Path destFile, CopyOption option1, CopyOption option2) throws IOException {
+        checkNotNullParam("option1", option1);
+        checkNotNullParam("option2", option2);
+        copyOrMove(sourceDir, srcFile, destDir, destFile,
+                parseCopyOption(option1) | parseCopyOption(option2) | OPT_MOVE | OPT_RECURSIVE);
+    }
+
+    /**
+     * Move a file as securely as possible from one directory and path to another.
+     * If both {@code srcFile} and {@code destFile} are {@linkplain Path#isAbsolute() absolute paths},
+     * then this method behaves exactly the same as {@link Files#move(Path, Path, CopyOption...)}.
+     * If {@code srcFile} and {@code destFile} are found to refer to the same file, then no action is taken
+     * and this method will return directly.
+     * <p>
+     * Otherwise, an attempt is made to:
+     * <ul>
+     * <li>Move symbolic links as symbolic links (when {@link LinkOption#NOFOLLOW_LINKS} is given)</li>
+     * <li>Move directories as directories (including their contents)</li>
+     * <li>Preserve file attributes (when {@link StandardCopyOption#COPY_ATTRIBUTES} is given)</li>
+     * <li>Move regular files using the most efficient JDK mechanism available</li>
+     * </ul>
+     * The operation may fail with a {@link IOException} if some part of the operation fails; in this case,
+     * the file may be partially copied.
+     * <p>
+     * If some aspect of the operation is not supported, {@link UnsupportedOperationException} will be thrown.
+     * Currently, the currently unsupported operations include:
+     * <ul>
+     * <li>Copying a symbolic link from or to a relative path (unsupported by the JDK as of JDK 25)</li>
+     * <li>Copying a directory into a relative path (unsupported by the JDK as of JDK 25)</li>
+     * </ul>
+     * The following move options are allowed:
+     * <ul>
+     * <li>{@link LinkOption#NOFOLLOW_LINKS}</li>
+     * <li>{@link StandardCopyOption#COPY_ATTRIBUTES}</li>
+     * <li>{@link StandardCopyOption#REPLACE_EXISTING}</li>
+     * <li>{@link StandardCopyOption#ATOMIC_MOVE}</li>
+     * </ul>
+     * Giving any other option will cause a {@link IllegalArgumentException} to be thrown.
+     *
+     * @param sourceDir the directory stream of the source directory (must not be {@code null})
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destDir the directory stream of the destination directory (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param options the move options to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if the combination of options is unsupported by the source or destination
+     *         filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during move
+     *
+     * @see SecureDirectoryStream#move(Object, SecureDirectoryStream, Object)
+     */
+    public static void move(SecureDirectoryStream<Path> sourceDir, Path srcFile, SecureDirectoryStream<Path> destDir,
+            Path destFile, CopyOption... options) throws IOException {
+        copyOrMove(sourceDir, srcFile, destDir, destFile, parseCopyOptions(options) | OPT_MOVE | OPT_RECURSIVE);
+    }
+
+    /**
+     * Move a file or directory, even if secure directory streams are not supported.
+     * <em>Warning:</em> this method can potentially move files outside the intended path
+     * if the target platform does not support secure directory iteration.
+     *
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @throws IOException if an I/O error occurs during move
+     *
+     * @see #move(Path, Path)
+     */
+    public static void moveEvenIfInsecure(Path srcFile, Path destFile) throws IOException {
+        checkNotNullParam("srcFile", srcFile);
+        checkNotNullParam("destFile", destFile);
+        SecureDirectoryStream<Path> base = CWD_SDS;
+        if (base != null) {
+            // secure!
+            move(base, srcFile, base, destFile);
+        } else {
+            moveInsecurely(srcFile, destFile);
+        }
+    }
+
+    /**
+     * Equivalent to calling {@link #move(Path, Path, CopyOption...)} with no options.
+     *
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @throws UnsupportedOperationException if secure directory traversal is unsupported or if the combination of options is
+     *         unsupported by the source or destination filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during move
+     *
+     * @see #move(Path, Path, CopyOption...)
+     */
+    public static void move(Path srcFile, Path destFile) throws IOException {
+        checkNotNullParam("srcFile", srcFile);
+        checkNotNullParam("destFile", destFile);
+        SecureDirectoryStream<Path> base = CWD_SDS;
+        if (base == null) {
+            throw Messages.log.secureDirectoryNotSupported(srcFile.getFileSystem(), srcFile);
+        }
+        move(base, srcFile, base, destFile);
+    }
+
+    /**
+     * Equivalent to calling {@link #move(Path, Path, CopyOption...)} with one option.
+     *
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param option1 the move option to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if secure directory traversal is unsupported or if the combination of options is
+     *         unsupported by the source or destination filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during move
+     *
+     * @see #move(Path, Path, CopyOption...)
+     */
+    public static void move(Path srcFile, Path destFile, CopyOption option1) throws IOException {
+        checkNotNullParam("srcFile", srcFile);
+        checkNotNullParam("destFile", destFile);
+        SecureDirectoryStream<Path> base = CWD_SDS;
+        if (base == null) {
+            throw Messages.log.secureDirectoryNotSupported(srcFile.getFileSystem(), srcFile);
+        }
+        move(base, srcFile, base, destFile, option1);
+    }
+
+    /**
+     * Equivalent to calling {@link #move(Path, Path, CopyOption...)} with two options.
+     *
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param option1 the first move option to use for the operation (must not be {@code null})
+     * @param option2 the second move option to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if secure directory traversal is unsupported or if the combination of options is
+     *         unsupported by the source or destination filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during move
+     *
+     * @see #move(Path, Path, CopyOption...)
+     */
+    public static void move(Path srcFile, Path destFile, CopyOption option1, CopyOption option2) throws IOException {
+        checkNotNullParam("srcFile", srcFile);
+        checkNotNullParam("destFile", destFile);
+        SecureDirectoryStream<Path> base = CWD_SDS;
+        if (base == null) {
+            throw Messages.log.secureDirectoryNotSupported(srcFile.getFileSystem(), srcFile);
+        }
+        move(base, srcFile, base, destFile, option1, option2);
+    }
+
+    /**
+     * Move a file as securely as possible from one path to another.
+     * This method uses a secure directory stream acquired from the current working directory
+     * to perform the operation.
+     * If {@code srcFile} and {@code destFile} are found to refer to the same file, then no action is taken
+     * and this method will return directly.
+     * <p>
+     * Otherwise, an attempt is made to:
+     * <ul>
+     * <li>Move symbolic links as symbolic links (when {@link LinkOption#NOFOLLOW_LINKS} is given)</li>
+     * <li>Move directories as directories (including their contents)</li>
+     * <li>Preserve file attributes (when {@link StandardCopyOption#COPY_ATTRIBUTES} is given)</li>
+     * <li>Move regular files using the most efficient JDK mechanism available</li>
+     * </ul>
+     * The operation may fail with a {@link IOException} if some part of the operation fails; in this case,
+     * the file may be partially copied.
+     * <p>
+     * If some aspect of the operation is not supported, {@link UnsupportedOperationException} will be thrown.
+     * Currently, the currently unsupported operations include:
+     * <ul>
+     * <li>Copying a symbolic link from or to a relative path (unsupported by the JDK as of JDK 25)</li>
+     * <li>Copying a directory into a relative path (unsupported by the JDK as of JDK 25)</li>
+     * </ul>
+     * The following move options are allowed:
+     * <ul>
+     * <li>{@link LinkOption#NOFOLLOW_LINKS}</li>
+     * <li>{@link StandardCopyOption#COPY_ATTRIBUTES}</li>
+     * <li>{@link StandardCopyOption#REPLACE_EXISTING}</li>
+     * <li>{@link StandardCopyOption#ATOMIC_MOVE}</li>
+     * </ul>
+     * Giving any other option will cause a {@link IllegalArgumentException} to be thrown.
+     *
+     * @param srcFile the source path name (must not be {@code null})
+     * @param destFile the destination path name (must not be {@code null})
+     * @param options the move options to use for the operation (must not be {@code null})
+     * @throws UnsupportedOperationException if secure directory traversal is unsupported or if the combination of options is
+     *         unsupported by the source or destination filesystem or the JDK itself
+     * @throws IOException if an I/O error occurs during move
+     *
+     * @see #move(SecureDirectoryStream, Path, SecureDirectoryStream, Path, CopyOption...)
+     */
+    public static void move(Path srcFile, Path destFile, CopyOption... options) throws IOException {
+        checkNotNullParam("srcFile", srcFile);
+        checkNotNullParam("destFile", destFile);
+        SecureDirectoryStream<Path> base = CWD_SDS;
+        if (base == null) {
+            throw Messages.log.secureDirectoryNotSupported(srcFile.getFileSystem(), srcFile);
+        }
+        move(base, srcFile, base, destFile, options);
+    }
+
+    /**
      * {@return the current working directory path at the time that this program was started (not {@code null})}
      * This path comes from the {@code user.dir} system property.
      */
@@ -572,8 +1379,8 @@ public final class Files2 {
 
     // -- private --
 
-    private static final Path CWD = Path.of(System.getProperty("user.dir", ".")).normalize().toAbsolutePath();
-    private static final SecureDirectoryStream<Path> CWD_SDS;
+    static final Path CWD = Path.of(System.getProperty("user.dir", ".")).normalize().toAbsolutePath();
+    static final SecureDirectoryStream<Path> CWD_SDS;
 
     static {
         SecureDirectoryStream<Path> cwdSds;
@@ -700,6 +1507,241 @@ public final class Files2 {
         } else {
             Files.delete(path);
         }
+    }
+
+    private static void copyInsecurely(final Path srcFile, final Path destFile) throws IOException {
+        log.tracef("Insecurely copying %s to %s", srcFile, destFile);
+        Files.copy(srcFile, destFile);
+    }
+
+    private static void copyRecursivelyInsecurely(final Path srcFile, final Path destFile) throws IOException {
+        log.tracef("Insecurely recursively copying %s to %s", srcFile, destFile);
+        if (Files.isDirectory(srcFile, LinkOption.NOFOLLOW_LINKS)) {
+            Files.createDirectory(destFile);
+            try (DirectoryStream<Path> ds = Files.newDirectoryStream(srcFile)) {
+                for (Path child : ds) {
+                    copyRecursivelyInsecurely(child, destFile.resolve(child.getFileName()));
+                }
+            }
+        } else {
+            Files.copy(srcFile, destFile, LinkOption.NOFOLLOW_LINKS);
+        }
+    }
+
+    private static void moveInsecurely(final Path srcFile, final Path destFile) throws IOException {
+        log.tracef("Insecurely moving %s to %s", srcFile, destFile);
+        Files.move(srcFile, destFile);
+    }
+
+    private static void copyOrMove(final SecureDirectoryStream<Path> srcDir, final Path srcFile,
+            final SecureDirectoryStream<Path> destDir, final Path destFile, final int opts) throws IOException {
+        if (has(opts, C_OPT_ATOMIC_MOVE) && !has(opts, OPT_MOVE)) {
+            throw log.unsupportedForOperation(StandardCopyOption.ATOMIC_MOVE);
+        }
+        if (srcFile.isAbsolute() && destFile.isAbsolute() && !has(opts, OPT_RECURSIVE)) {
+            // use the JDK methods
+            if (has(opts, OPT_MOVE)) {
+                Files.move(srcFile, destFile, ALL_COPY_OPTIONS[opts]);
+            } else {
+                Files.copy(srcFile, destFile, ALL_COPY_OPTIONS[opts]);
+            }
+            return;
+        }
+        // first, get attributes to ensure that the source file exists (throws here if not found)
+        PosixFileAttributeView srcPosixView = srcDir.getFileAttributeView(srcFile, PosixFileAttributeView.class,
+                ALL_LINK_OPTIONS[opts & OPT_NO_FOLLOW]);
+        PosixFileAttributes srcPosix = srcPosixView == null ? null : srcPosixView.readAttributes();
+        DosFileAttributeView srcDosView = srcPosix != null ? null
+                : srcDir.getFileAttributeView(srcFile, DosFileAttributeView.class, ALL_LINK_OPTIONS[opts & OPT_NO_FOLLOW]);
+        DosFileAttributes srcDos = srcDosView == null ? null : srcDosView.readAttributes();
+        BasicFileAttributes srcBasic = srcPosix != null ? srcPosix
+                : srcDos != null ? srcDos
+                        : srcDir.getFileAttributeView(srcFile, BasicFileAttributeView.class,
+                                ALL_LINK_OPTIONS[opts & OPT_NO_FOLLOW]).readAttributes();
+        // source file exists; continue
+        FileAttribute<?>[] attrs = has(opts, C_OPT_COPY_ATTRS) && srcPosix != null ? new FileAttribute[] {
+                PosixFilePermissions.asFileAttribute(srcPosix.permissions())
+        } : NO_FILE_ATTRS;
+        BasicFileAttributes oldDestBasic = null;
+        try {
+            // always use nofollow-links on the destination so we know what to do about it
+            oldDestBasic = destDir.getFileAttributeView(destFile, BasicFileAttributeView.class, ALL_LINK_OPTIONS[OPT_NO_FOLLOW])
+                    .readAttributes();
+        } catch (NoSuchFileException ignored) {
+        }
+        if (oldDestBasic != null) {
+            // try to determine if they are the same file
+            Object srcKey = srcBasic.fileKey();
+            if (srcKey != null && srcKey.equals(oldDestBasic.fileKey())) {
+                // same file; nothing to do
+                return;
+            }
+            // different file, or don't know
+            if (!has(opts, C_OPT_REPLACE)) {
+                throw log.copyFileExists(destFile);
+            }
+            // remove the dest. path
+            if (oldDestBasic.isDirectory()) {
+                // non-recursive removal; fails if directory is not empty
+                destDir.deleteDirectory(destFile);
+            } else {
+                destDir.deleteFile(destFile);
+            }
+        }
+        if (has(opts, OPT_MOVE)) {
+            try {
+                srcDir.move(srcFile, destDir, destFile);
+                return;
+            } catch (AtomicMoveNotSupportedException e) {
+                if (has(opts, C_OPT_ATOMIC_MOVE)) {
+                    throw e;
+                }
+                // else do a copy+delete instead
+            }
+        }
+        // now check the source type
+        boolean isDirectory = srcBasic.isDirectory();
+        if (isDirectory) {
+            JDKSpecificDirectoryActions.createDirectory(destDir, destFile, attrs);
+            if (has(opts, OPT_RECURSIVE)) {
+                try (SecureDirectoryStream<Path> srcFileSds = srcDir.newDirectoryStream(srcFile,
+                        ALL_LINK_OPTIONS[opts & OPT_NO_FOLLOW])) {
+                    try (SecureDirectoryStream<Path> destFileSds = destDir.newDirectoryStream(destFile,
+                            ALL_LINK_OPTIONS[OPT_NO_FOLLOW])) {
+                        for (Path subPath : srcFileSds) {
+                            Path fileName = subPath.getFileName();
+                            // always use NOFOLLOW_LINKS for recursive children;
+                            // the option only applies to the initial path
+                            copyOrMove(srcFileSds, fileName, destFileSds, fileName, opts | OPT_NO_FOLLOW);
+                        }
+                    }
+                }
+            }
+        } else if (srcBasic.isSymbolicLink()) {
+            Path target = JDKSpecificDirectoryActions.readLink(srcDir, srcFile);
+            JDKSpecificDirectoryActions.createSymlink(destDir, destFile, target, attrs);
+        } else {
+            // regular file
+            Set<? extends OpenOption> destOpenOpts = ALL_OPEN_OPTIONS_FOR_COPY_WRITE.get(opts & OPT_NO_FOLLOW);
+            try (SeekableByteChannel destCh = destDir.newByteChannel(destFile, destOpenOpts, attrs)) {
+                // now open source channel
+                Set<? extends OpenOption> srcOpenOpts = ALL_OPEN_OPTIONS_FOR_COPY_READ.get(opts & OPT_NO_FOLLOW);
+                try (SeekableByteChannel srcCh = srcDir.newByteChannel(srcFile, srcOpenOpts)) {
+                    // do the copy
+                    copy(srcCh, destCh);
+                }
+            }
+        }
+        // copy attributes
+        if (has(opts, C_OPT_COPY_ATTRS)) {
+            PosixFileAttributeView newDestPosixView = destDir.getFileAttributeView(destFile, PosixFileAttributeView.class,
+                    ALL_LINK_OPTIONS[OPT_NO_FOLLOW]);
+            DosFileAttributeView newDestDosView = newDestPosixView != null ? null
+                    : destDir.getFileAttributeView(destFile, DosFileAttributeView.class, ALL_LINK_OPTIONS[OPT_NO_FOLLOW]);
+            BasicFileAttributeView newDestBasicView = newDestPosixView != null ? newDestPosixView
+                    : newDestDosView != null ? newDestDosView
+                            : destDir.getFileAttributeView(destFile, BasicFileAttributeView.class,
+                                    ALL_LINK_OPTIONS[OPT_NO_FOLLOW]);
+            if (srcPosix != null && newDestPosixView != null) {
+                // copy owner/group
+                newDestPosixView.setOwner(srcPosix.owner());
+                newDestPosixView.setGroup(srcPosix.group());
+            } else if (srcDos != null && newDestDosView != null) {
+                // copy RASH
+                newDestDosView.setReadOnly(srcDos.isReadOnly());
+                newDestDosView.setArchive(srcDos.isArchive());
+                newDestDosView.setSystem(srcDos.isSystem());
+                newDestDosView.setHidden(srcDos.isHidden());
+            }
+            // copy times
+            newDestBasicView.setTimes(srcBasic.lastModifiedTime(), srcBasic.lastAccessTime(), srcBasic.creationTime());
+        }
+        // remove old, if moving
+        if (has(opts, OPT_MOVE)) {
+            if (isDirectory) {
+                srcDir.deleteDirectory(srcFile);
+            } else {
+                srcDir.deleteFile(srcFile);
+            }
+        }
+    }
+
+    private static final int OPT_NO_FOLLOW = 1 << 0;
+
+    private static final int C_OPT_REPLACE = 1 << 1;
+    private static final int C_OPT_COPY_ATTRS = 1 << 2;
+    private static final int C_OPT_ATOMIC_MOVE = 1 << 3;
+
+    private static final int OPT_MOVE = 1 << 4;
+    private static final int OPT_RECURSIVE = 1 << 5;
+
+    private static int parseCopyOptions(final CopyOption... options) {
+        checkNotNullParam("options", options);
+        int opts = 0;
+        for (int i = 0; i < options.length; i++) {
+            final CopyOption option = options[i];
+            checkNotNullArrayParam("options", i, option);
+            opts |= parseCopyOption(option);
+        }
+        return opts;
+    }
+
+    private static int parseCopyOption(final CopyOption option) {
+        if (option instanceof StandardCopyOption o) {
+            return switch (o) {
+                case REPLACE_EXISTING -> C_OPT_REPLACE;
+                case COPY_ATTRIBUTES -> C_OPT_COPY_ATTRS;
+                case ATOMIC_MOVE -> C_OPT_ATOMIC_MOVE;
+                //noinspection UnnecessaryDefault
+                default -> throw log.unknownOption(o);
+            };
+        } else if (option instanceof LinkOption o) {
+            if (o == LinkOption.NOFOLLOW_LINKS) {
+                return OPT_NO_FOLLOW;
+            } else {
+                throw log.unknownOption(o);
+            }
+        } else {
+            throw log.unknownOption(option);
+        }
+    }
+
+    private static boolean has(int opts, int option) {
+        return (opts & option) != 0;
+    }
+
+    private static final LinkOption[][] ALL_LINK_OPTIONS = {
+            {},
+            { LinkOption.NOFOLLOW_LINKS }
+    };
+    private static final CopyOption[][] ALL_COPY_OPTIONS;
+    // order is significant
+    private static final List<Set<? extends OpenOption>> ALL_OPEN_OPTIONS_FOR_COPY_WRITE = List.of(
+            EnumSet.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE),
+            Set.of(LinkOption.NOFOLLOW_LINKS, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE));
+    private static final List<Set<? extends OpenOption>> ALL_OPEN_OPTIONS_FOR_COPY_READ = List.of(
+            EnumSet.noneOf(StandardOpenOption.class),
+            EnumSet.of(LinkOption.NOFOLLOW_LINKS));
+    private static final FileAttribute<?>[] NO_FILE_ATTRS = new FileAttribute[0];
+
+    static {
+        CopyOption[][] outer = new CopyOption[16][];
+        for (int i = 0; i < 16; i++) {
+            CopyOption[] inner = new CopyOption[Integer.bitCount(i)];
+            int bits = i, idx = 0;
+            while (bits != 0) {
+                inner[idx++] = switch (Integer.numberOfTrailingZeros(bits)) {
+                    case 0 -> LinkOption.NOFOLLOW_LINKS;
+                    case 1 -> StandardCopyOption.REPLACE_EXISTING;
+                    case 2 -> StandardCopyOption.COPY_ATTRIBUTES;
+                    case 3 -> StandardCopyOption.ATOMIC_MOVE;
+                    default -> throw impossibleSwitchCase(bits);
+                };
+                bits &= ~Integer.lowestOneBit(bits);
+            }
+            outer[i] = inner;
+        }
+        ALL_COPY_OPTIONS = outer;
     }
 
 }

--- a/io/src/main/java/io/smallrye/common/io/JDKSpecificDirectoryActions.java
+++ b/io/src/main/java/io/smallrye/common/io/JDKSpecificDirectoryActions.java
@@ -1,0 +1,149 @@
+package io.smallrye.common.io;
+
+import static io.smallrye.common.io.Messages.log;
+
+import java.io.IOException;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.SecureDirectoryStream;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+final class JDKSpecificDirectoryActions {
+    private JDKSpecificDirectoryActions() {
+    }
+
+    static Path readLink(SecureDirectoryStream<Path> sds, Path path) throws IOException {
+        if (path.isAbsolute()) {
+            return Files.readSymbolicLink(path);
+        } else {
+            // try to find the absolute path of the symlink (slow)
+            if (path.getNameCount() > 1) {
+                try (SecureDirectoryStream<Path> subSds = sds.newDirectoryStream(path.getName(0))) {
+                    return readLink(subSds, path.subpath(1, path.getNameCount()));
+                }
+            }
+            // try to find it...
+            try (SecureDirectoryStream<Path> sdsClone = sds.newDirectoryStream(Path.of("."))) {
+                for (Path subPath : sdsClone) {
+                    if (subPath.getFileName().toString().equals(path.getFileName().toString())) {
+                        // found it!
+                        BasicFileAttributes rbfa = sdsClone
+                                .getFileAttributeView(subPath.getFileName(), BasicFileAttributeView.class,
+                                        LinkOption.NOFOLLOW_LINKS)
+                                .readAttributes();
+                        BasicFileAttributes abfa = Files
+                                .getFileAttributeView(subPath, BasicFileAttributeView.class, LinkOption.NOFOLLOW_LINKS)
+                                .readAttributes();
+                        if (rbfa.fileKey().equals(abfa.fileKey())) {
+                            return Files.readSymbolicLink(subPath);
+                        } else {
+                            // just fail
+                            break;
+                        }
+                    }
+                }
+            }
+            throw log.secureReadlinkNotSupported();
+        }
+    }
+
+    static void createSymlink(SecureDirectoryStream<Path> sds, Path path, Path target, FileAttribute<?>... attrs)
+            throws IOException {
+        if (path.isAbsolute()) {
+            Files.createSymbolicLink(path, target, attrs);
+        } else {
+            // Create the symlink under what we assume is the proper path,
+            // then atomically move it into the target directory stream at the desired path.
+            Path tempName = tempName(path);
+            // first, create a probe file
+            Path tempFullPath;
+            try (SeekableByteChannel ignored = sds.newByteChannel(tempName,
+                    Set.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE))) {
+                try (SecureDirectoryStream<Path> sdsClone = sds.newDirectoryStream(Path.of("."))) {
+                    Iterator<Path> itr = sdsClone.iterator();
+                    Path sdsAbsPath = itr.next().getParent();
+                    if (sdsAbsPath == null) {
+                        throw log.secureMkdirNotSupported();
+                    }
+                    tempFullPath = sdsAbsPath.resolve(tempName);
+                }
+            } catch (Throwable t) {
+                try {
+                    sds.deleteFile(tempName);
+                } catch (Throwable t2) {
+                    t.addSuppressed(t2);
+                }
+                throw t;
+            }
+            // now that we have the full path, delete the probe file and try to create a directory there.
+            sds.deleteFile(tempName);
+            Files.createSymbolicLink(tempFullPath, target, attrs);
+            try {
+                sds.move(tempFullPath, sds, path);
+            } catch (Throwable t) {
+                try {
+                    Files.delete(tempFullPath);
+                } catch (IOException t2) {
+                    t.addSuppressed(t2);
+                }
+                throw t;
+            }
+        }
+    }
+
+    private static Path tempName(final Path path) {
+        return Path
+                .of(path.getFileName().toString() + ".temp" + Long.toHexString(ThreadLocalRandom.current().nextLong()));
+    }
+
+    static void createDirectory(SecureDirectoryStream<Path> sds, Path path, FileAttribute<?>... attrs) throws IOException {
+        if (path.isAbsolute()) {
+            Files.createDirectory(path, attrs);
+        } else {
+            // Create the directory under what we assume is the proper path,
+            // then atomically move it into the target directory stream at the desired path.
+            Path tempName = tempName(path);
+            // first, create a probe file
+            Path tempFullPath;
+            try (SeekableByteChannel ignored = sds.newByteChannel(tempName,
+                    Set.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE))) {
+                try (SecureDirectoryStream<Path> sdsClone = sds.newDirectoryStream(Path.of("."))) {
+                    Iterator<Path> itr = sdsClone.iterator();
+                    Path sdsAbsPath = itr.next().getParent();
+                    if (sdsAbsPath == null) {
+                        throw log.secureMkdirNotSupported();
+                    }
+                    tempFullPath = sdsAbsPath.resolve(tempName);
+                }
+            } catch (Throwable t) {
+                try {
+                    sds.deleteFile(tempName);
+                } catch (Throwable t2) {
+                    t.addSuppressed(t2);
+                }
+                throw t;
+            }
+            // now that we have the full path, delete the probe file and try to create a directory there.
+            sds.deleteFile(tempName);
+            Files.createDirectory(tempFullPath, attrs);
+            try {
+                sds.move(tempFullPath, sds, path);
+            } catch (Throwable t) {
+                try {
+                    Files.delete(tempFullPath);
+                } catch (IOException t2) {
+                    t.addSuppressed(t2);
+                }
+                throw t;
+            }
+        }
+    }
+}

--- a/io/src/main/java/io/smallrye/common/io/Messages.java
+++ b/io/src/main/java/io/smallrye/common/io/Messages.java
@@ -2,6 +2,8 @@ package io.smallrye.common.io;
 
 import static java.lang.invoke.MethodHandles.lookup;
 
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
 
@@ -15,4 +17,25 @@ interface Messages extends BasicLogger {
 
     @Message(id = 4000, value = "Secure directory streams not supported by %s for path \"%s\"")
     UnsupportedOperationException secureDirectoryNotSupported(FileSystem fileSystem, Path path);
+
+    @Message(id = 4001, value = "An unrecognized option was given: %s")
+    IllegalArgumentException unknownOption(Object option);
+
+    @Message(id = 4002, value = "Unexpected partial copy from %s to %s (expected to copy %d bytes, but only copied %d bytes)")
+    IOException partialCopy(Object in, Object out, long expected, long actual);
+
+    @Message(id = 4003, value = "Symbolic link creation in a secure directory is not supported by this JDK")
+    UnsupportedOperationException secureSymlinkNotSupported();
+
+    @Message(id = 4004, value = "Directory creation in a secure directory is not supported by this JDK")
+    UnsupportedOperationException secureMkdirNotSupported();
+
+    @Message(id = 4005, value = "File \"%s\" already exists, and REPLACE_EXISTING was not given")
+    FileAlreadyExistsException copyFileExists(Path destFile);
+
+    @Message(id = 4006, value = "Symbolic link reading in a secure directory is not supported by this JDK")
+    UnsupportedOperationException secureReadlinkNotSupported();
+
+    @Message(id = 4007, value = "Option %s is not supported for this operation")
+    IllegalArgumentException unsupportedForOperation(Object option);
 }

--- a/io/src/test/java/io/smallrye/common/io/Files2Test.java
+++ b/io/src/test/java/io/smallrye/common/io/Files2Test.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -202,5 +203,236 @@ public class Files2Test {
         assertEquals(0, stats.filesRemoved());
         assertEquals(0, stats.directoriesFound());
         assertEquals(0, stats.directoriesRemoved());
+    }
+
+    @Test
+    public void testCopy() throws IOException {
+        assumeTrue(Files2.hasSecureDirectories());
+        Path testArea = Path.of("target/test-area");
+        assumeFalse(Files.exists(testArea));
+        makeStructure(testArea);
+        Path srcFile = testArea.resolve("blah.bin");
+        Path destFile = testArea.resolve("blah-copy.bin");
+        assertTrue(Files.exists(srcFile));
+        Files2.copy(srcFile, destFile);
+        assertTrue(Files.exists(srcFile));
+        assertTrue(Files.exists(destFile));
+        assertEquals(Files.size(srcFile), Files.size(destFile));
+        Files2.deleteRecursively(testArea);
+        assertFalse(Files.exists(testArea));
+    }
+
+    @Test
+    public void testCopyAbsolute(@TempDir Path testArea) throws IOException {
+        assumeTrue(Files2.hasSecureDirectories());
+        makeStructure(testArea);
+        Path srcFile = testArea.resolve("blah.bin");
+        Path destFile = testArea.resolve("blah-copy.bin");
+        assertTrue(Files.exists(srcFile));
+        Files2.copy(srcFile, destFile);
+        assertTrue(Files.exists(srcFile));
+        assertTrue(Files.exists(destFile));
+        assertEquals(Files.size(srcFile), Files.size(destFile));
+    }
+
+    @Test
+    public void testCopyReplaceExisting(@TempDir Path testArea) throws IOException {
+        assumeTrue(Files2.hasSecureDirectories());
+        makeStructure(testArea);
+        Path srcFile = testArea.resolve("blah.bin");
+        Path destFile = testArea.resolve("empty.txt");
+        long srcSize = Files.size(srcFile);
+        assertTrue(Files.exists(srcFile));
+        assertTrue(Files.exists(destFile));
+        Files2.copy(srcFile, destFile, StandardCopyOption.REPLACE_EXISTING);
+        assertTrue(Files.exists(srcFile));
+        assertTrue(Files.exists(destFile));
+        assertEquals(srcSize, Files.size(destFile));
+    }
+
+    @Test
+    public void testCopyEvenIfInsecure() throws IOException {
+        Path testArea = Path.of("target/test-area");
+        assumeFalse(Files.exists(testArea));
+        makeStructure(testArea);
+        Path srcFile = testArea.resolve("blah.bin");
+        Path destFile = testArea.resolve("blah-copy.bin");
+        assertTrue(Files.exists(srcFile));
+        Files2.copyEvenIfInsecure(srcFile, destFile);
+        assertTrue(Files.exists(srcFile));
+        assertTrue(Files.exists(destFile));
+        assertEquals(Files.size(srcFile), Files.size(destFile));
+        Files2.deleteRecursivelyEvenIfInsecure(testArea);
+        assertFalse(Files.exists(testArea));
+    }
+
+    @Test
+    public void testCopyRecursively() throws IOException {
+        assumeTrue(Files2.hasSecureDirectories());
+        Path testArea = Path.of("target/test-area");
+        Path destArea = Path.of("target/test-area-copy");
+        assumeFalse(Files.exists(testArea));
+        assumeFalse(Files.exists(destArea));
+        makeStructure(testArea);
+        assertTrue(Files.exists(testArea));
+        Files2.copyRecursively(testArea, destArea);
+        // verify source is still intact
+        assertTrue(Files.exists(testArea));
+        assertTrue(Files.exists(testArea.resolve("blah.bin")));
+        // verify dest structure
+        assertTrue(Files.exists(destArea));
+        assertTrue(Files.exists(destArea.resolve("blah.bin")));
+        assertTrue(Files.exists(destArea.resolve("empty.txt")));
+        assertTrue(Files.exists(destArea.resolve("subDir")));
+        assertTrue(Files.exists(destArea.resolve("subDir").resolve("subfile")));
+        assertTrue(Files.exists(destArea.resolve("subDir").resolve("subDir2").resolve("subDir3").resolve("innermost")));
+        assertEquals(Files.size(testArea.resolve("blah.bin")), Files.size(destArea.resolve("blah.bin")));
+        Files2.deleteRecursively(testArea);
+        Files2.deleteRecursively(destArea);
+        assertFalse(Files.exists(testArea));
+        assertFalse(Files.exists(destArea));
+    }
+
+    @Test
+    public void testCopyRecursivelyAbsolute(@TempDir Path testArea) throws IOException {
+        assumeTrue(Files2.hasSecureDirectories());
+        Path srcDir = testArea.resolve("src");
+        Path destDir = testArea.resolve("dest");
+        makeStructure(srcDir);
+        assertTrue(Files.exists(srcDir));
+        Files2.copyRecursively(srcDir, destDir);
+        // verify source is still intact
+        assertTrue(Files.exists(srcDir));
+        assertTrue(Files.exists(srcDir.resolve("blah.bin")));
+        // verify dest structure
+        assertTrue(Files.exists(destDir));
+        assertTrue(Files.exists(destDir.resolve("blah.bin")));
+        assertTrue(Files.exists(destDir.resolve("empty.txt")));
+        assertTrue(Files.exists(destDir.resolve("subDir")));
+        assertTrue(Files.exists(destDir.resolve("subDir").resolve("subfile")));
+        assertTrue(Files.exists(destDir.resolve("subDir").resolve("subDir2").resolve("subDir3").resolve("innermost")));
+        assertEquals(Files.size(srcDir.resolve("blah.bin")), Files.size(destDir.resolve("blah.bin")));
+    }
+
+    @Test
+    public void testCopyRecursivelyEvenIfInsecure() throws IOException {
+        Path testArea = Path.of("target/test-area");
+        Path destArea = Path.of("target/test-area-copy");
+        assumeFalse(Files.exists(testArea));
+        assumeFalse(Files.exists(destArea));
+        makeStructure(testArea);
+        assertTrue(Files.exists(testArea));
+        Files2.copyRecursivelyEvenIfInsecure(testArea, destArea);
+        // verify source is still intact
+        assertTrue(Files.exists(testArea));
+        assertTrue(Files.exists(testArea.resolve("blah.bin")));
+        // verify dest structure
+        assertTrue(Files.exists(destArea));
+        assertTrue(Files.exists(destArea.resolve("blah.bin")));
+        assertTrue(Files.exists(destArea.resolve("empty.txt")));
+        assertTrue(Files.exists(destArea.resolve("subDir")));
+        assertTrue(Files.exists(destArea.resolve("subDir").resolve("subfile")));
+        assertTrue(Files.exists(destArea.resolve("subDir").resolve("subDir2").resolve("subDir3").resolve("innermost")));
+        assertEquals(Files.size(testArea.resolve("blah.bin")), Files.size(destArea.resolve("blah.bin")));
+        Files2.deleteRecursivelyEvenIfInsecure(testArea);
+        Files2.deleteRecursivelyEvenIfInsecure(destArea);
+        assertFalse(Files.exists(testArea));
+        assertFalse(Files.exists(destArea));
+    }
+
+    @Test
+    public void testMove() throws IOException {
+        assumeTrue(Files2.hasSecureDirectories());
+        Path testArea = Path.of("target/test-area");
+        Path destArea = Path.of("target/test-area-moved");
+        assumeFalse(Files.exists(testArea));
+        assumeFalse(Files.exists(destArea));
+        makeStructure(testArea);
+        assertTrue(Files.exists(testArea));
+        Files2.move(testArea, destArea);
+        // verify source is gone
+        assertFalse(Files.exists(testArea));
+        // verify dest structure
+        assertTrue(Files.exists(destArea));
+        assertTrue(Files.exists(destArea.resolve("blah.bin")));
+        assertTrue(Files.exists(destArea.resolve("empty.txt")));
+        assertTrue(Files.exists(destArea.resolve("subDir")));
+        assertTrue(Files.exists(destArea.resolve("subDir").resolve("subfile")));
+        assertTrue(Files.exists(destArea.resolve("subDir").resolve("subDir2").resolve("subDir3").resolve("innermost")));
+        Files2.deleteRecursively(destArea);
+        assertFalse(Files.exists(destArea));
+    }
+
+    @Test
+    public void testMoveAbsolute(@TempDir Path testArea) throws IOException {
+        assumeTrue(Files2.hasSecureDirectories());
+        Path srcDir = testArea.resolve("src");
+        Path destDir = testArea.resolve("dest");
+        makeStructure(srcDir);
+        assertTrue(Files.exists(srcDir));
+        Files2.move(srcDir, destDir);
+        // verify source is gone
+        assertFalse(Files.exists(srcDir));
+        // verify dest structure
+        assertTrue(Files.exists(destDir));
+        assertTrue(Files.exists(destDir.resolve("blah.bin")));
+        assertTrue(Files.exists(destDir.resolve("empty.txt")));
+        assertTrue(Files.exists(destDir.resolve("subDir")));
+        assertTrue(Files.exists(destDir.resolve("subDir").resolve("subfile")));
+        assertTrue(Files.exists(destDir.resolve("subDir").resolve("subDir2").resolve("subDir3").resolve("innermost")));
+    }
+
+    @Test
+    public void testMoveFile() throws IOException {
+        assumeTrue(Files2.hasSecureDirectories());
+        Path testArea = Path.of("target/test-area");
+        assumeFalse(Files.exists(testArea));
+        makeStructure(testArea);
+        Path srcFile = testArea.resolve("blah.bin");
+        Path destFile = testArea.resolve("blah-moved.bin");
+        long srcSize = Files.size(srcFile);
+        assertTrue(Files.exists(srcFile));
+        Files2.move(srcFile, destFile);
+        assertFalse(Files.exists(srcFile));
+        assertTrue(Files.exists(destFile));
+        assertEquals(srcSize, Files.size(destFile));
+        Files2.deleteRecursively(testArea);
+        assertFalse(Files.exists(testArea));
+    }
+
+    @Test
+    public void testMoveFileAbsolute(@TempDir Path testArea) throws IOException {
+        assumeTrue(Files2.hasSecureDirectories());
+        makeStructure(testArea);
+        Path srcFile = testArea.resolve("blah.bin");
+        Path destFile = testArea.resolve("blah-moved.bin");
+        long srcSize = Files.size(srcFile);
+        assertTrue(Files.exists(srcFile));
+        Files2.move(srcFile, destFile);
+        assertFalse(Files.exists(srcFile));
+        assertTrue(Files.exists(destFile));
+        assertEquals(srcSize, Files.size(destFile));
+    }
+
+    @Test
+    public void testMoveEvenIfInsecure() throws IOException {
+        Path testArea = Path.of("target/test-area");
+        Path destArea = Path.of("target/test-area-moved");
+        assumeFalse(Files.exists(testArea));
+        assumeFalse(Files.exists(destArea));
+        makeStructure(testArea);
+        assertTrue(Files.exists(testArea));
+        Files2.moveEvenIfInsecure(testArea, destArea);
+        // verify source is gone
+        assertFalse(Files.exists(testArea));
+        // verify dest structure
+        assertTrue(Files.exists(destArea));
+        assertTrue(Files.exists(destArea.resolve("blah.bin")));
+        assertTrue(Files.exists(destArea.resolve("empty.txt")));
+        assertTrue(Files.exists(destArea.resolve("subDir")));
+        assertTrue(Files.exists(destArea.resolve("subDir").resolve("subfile")));
+        assertTrue(Files.exists(destArea.resolve("subDir").resolve("subDir2").resolve("subDir3").resolve("innermost")));
+        Files2.deleteRecursivelyEvenIfInsecure(destArea);
+        assertFalse(Files.exists(destArea));
     }
 }


### PR DESCRIPTION
Fixes #484.

This is a draft to allow review of the API and basic implementation as I write tests. Based on #482.

- [x] `copy` (SDS input)
   - [x] Tests
- [x] `copy` (Path input only)
   - [x] Tests
- [x] `copyRecursively` (SDS input)
   - [x] Tests
- [x] `copyRecursively` (Path input only)
   - [x] Tests
- [x] `move` (SDS input)
   - [x] Tests
- [x] `move` (Path input only)
   - [x] Tests
- [x] `copyEvenIfInsecure` (Path input only)
   - [x] Tests
- [x] `copyRecursivelyEvenIfInsecure` (Path input only)
   - [x] Tests
- [x] `moveEvenIfInsecure` (Path input only)
   - [x] Tests
