### PR TITLE
Fix ProcessUtil.pathOfCommand(Path path) on Windows

### DIFF
--- a/process/src/main/java/io/smallrye/common/process/ProcessUtil.java
+++ b/process/src/main/java/io/smallrye/common/process/ProcessUtil.java
@@ -92,9 +92,6 @@ public final class ProcessUtil {
         }
         for (Path segment : searchPath()) {
             Path execPath = segment.resolve(path);
-            if (Files.isExecutable(execPath)) {
-                return Optional.of(execPath);
-            }
             if (OS.current() == OS.WINDOWS) {
                 for (String ext : Windows.pathExt) {
                     Path execPathExt = execPath.getParent().resolve(execPath.getFileName() + ext);
@@ -102,6 +99,9 @@ public final class ProcessUtil {
                         return Optional.of(execPathExt);
                     }
                 }
+            }
+            if (Files.isExecutable(execPath)) {
+                return Optional.of(execPath);
             }
         }
         return Optional.empty();


### PR DESCRIPTION
Currently, when I execute the following on my Windows machine:

```
ProcessUtil.pathOfCommand(Path.of("docker"));
```

it returns `C:\Program Files\Docker\Docker\resources\bin\docker` because the file `docker` does exist, while what we are looking for is `docker.exe`:

<img width="523" height="251" alt="ssss" src="https://github.com/user-attachments/assets/2cdd0260-2e46-4d32-9ba6-1eec321043d1" />

This PR will prioritize selecting executable files with extension over executable files without extension, on Windows only.
Or should we drop looking for executable files without extension on Windows at all?