### PR TITLE
Fix a case-sensitive issue with ProcessUtil.pathOfCommand(Path path) on Windows

### DIFF
--- a/process/src/main/java/io/smallrye/common/process/ProcessUtil.java
+++ b/process/src/main/java/io/smallrye/common/process/ProcessUtil.java
@@ -223,6 +223,7 @@ public final class ProcessUtil {
         private static final List<String> pathExt = Stream
                 .of(getenv("PATHEXT").split(File.pathSeparator))
                 .filter(s -> !s.isEmpty())
+                .map(String::toLowerCase)
                 .toList();
     }
 


### PR DESCRIPTION
Currently, `ProcessUtil.pathOfCommand(Path.of("docker"))` will return `C:\Program Files\Docker\Docker\resources\bin\docker.EXE` instead of `C:\Program Files\Docker\Docker\resources\bin\docker.exe`.

This PR will fix a recent bug in latest Quarkus with podman detection on Windows:

```
public final class ContainerRuntimeUtil {

    private static final Pattern PODMAN_PATTERN = Pattern.compile("^podman(?:\\.exe)? version.*", Pattern.DOTALL);
```

Notice that the podman version output pattern expects that the `.exe` must be in lower case if exist.

I thought about fixing this bug in Quarkus repo, but I noticed that `ProcessUtil.pathOfCommand` is used in many places in Quarkus codebase, so fixing it here could potentially fix other bugs.