### PR TITLE
Add module annotations for `Add-Opens`, `Add-Exports`, `Enable-Native-Access`

### DIFF
--- a/annotation/src/main/java/io/smallrye/common/annotation/AddExports.java
+++ b/annotation/src/main/java/io/smallrye/common/annotation/AddExports.java
@@ -1,0 +1,43 @@
+package io.smallrye.common.annotation;
+
+import static java.lang.annotation.ElementType.MODULE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Declare that a module's packages should be exported to the annotated module.
+ * <p>
+ * This annotation is only respected by certain cooperating tools and runtimes.
+ */
+@Retention(CLASS)
+@Target(MODULE)
+@Repeatable(AddExports.List.class)
+@Documented
+public @interface AddExports {
+    /**
+     * {@return the module name to export from}
+     */
+    String module();
+
+    /**
+     * {@return the packages which should be exported}
+     */
+    String[] packages();
+
+    /**
+     * The repeating holder annotation for {@link AddExports}.
+     */
+    @Retention(CLASS)
+    @Target(MODULE)
+    @Documented
+    @interface List {
+        /**
+         * {@return the annotations}
+         */
+        AddExports[] value();
+    }
+}

--- a/annotation/src/main/java/io/smallrye/common/annotation/AddOpens.java
+++ b/annotation/src/main/java/io/smallrye/common/annotation/AddOpens.java
@@ -1,0 +1,43 @@
+package io.smallrye.common.annotation;
+
+import static java.lang.annotation.ElementType.MODULE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Declare that a module's packages should be opened to the annotated module.
+ * <p>
+ * This annotation is only respected by certain cooperating tools and runtimes.
+ */
+@Retention(CLASS)
+@Target(MODULE)
+@Repeatable(AddOpens.List.class)
+@Documented
+public @interface AddOpens {
+    /**
+     * {@return the module name to open from}
+     */
+    String module();
+
+    /**
+     * {@return the packages which should be opened}
+     */
+    String[] packages();
+
+    /**
+     * The repeating holder annotation for {@link AddOpens}.
+     */
+    @Retention(CLASS)
+    @Target(MODULE)
+    @Documented
+    @interface List {
+        /**
+         * {@return the annotations}
+         */
+        AddOpens[] value();
+    }
+}

--- a/annotation/src/main/java/io/smallrye/common/annotation/NativeAccess.java
+++ b/annotation/src/main/java/io/smallrye/common/annotation/NativeAccess.java
@@ -1,0 +1,19 @@
+package io.smallrye.common.annotation;
+
+import static java.lang.annotation.ElementType.MODULE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Declare that the annotated module requests native access.
+ * <p>
+ * This annotation is only respected by certain cooperating tools and runtimes.
+ */
+@Retention(CLASS)
+@Target(MODULE)
+@Documented
+public @interface NativeAccess {
+}


### PR DESCRIPTION
These annotations may be consumed by tooling or by the upcoming Quarkus module loader implementation.

/cc @gastaldi @Sanne @cescoffier