### PR TITLE
Add `file()` and `hasFile()` to `PathResource`

### DIFF
--- a/resource/src/main/java/io/smallrye/common/resource/JarFileResourceLoader.java
+++ b/resource/src/main/java/io/smallrye/common/resource/JarFileResourceLoader.java
@@ -36,19 +36,14 @@ public final class JarFileResourceLoader implements ResourceLoader {
     public JarFileResourceLoader(final Resource resource) throws IOException {
         // todo: this will be replaced with a version which opens the file in-place from a buffer
         base = resource.url();
-        JarFile jf = null;
-        if (resource instanceof PathResource pr) {
-            try {
-                // avoid using a temp file, if possible
-                jf = new JarFile(pr.path().toFile(), true, JarFile.OPEN_READ, JarFile.runtimeVersion());
-            } catch (UnsupportedOperationException ignored) {
-            }
-        }
-        if (jf == null) {
+        if (resource instanceof PathResource pr && pr.hasFile()) {
+            // avoid using a temp file, if possible
+            jarFile = new JarFile(pr.file(), true, JarFile.OPEN_READ, JarFile.runtimeVersion());
+        } else {
             tempFile = Files.createTempFile("srcr-tmp-", ".jar");
             try {
                 resource.copyTo(tempFile);
-                jf = new JarFile(tempFile.toFile(), true, JarFile.OPEN_READ, JarFile.runtimeVersion());
+                jarFile = new JarFile(tempFile.toFile(), true, JarFile.OPEN_READ, JarFile.runtimeVersion());
             } catch (Throwable t) {
                 try {
                     Files.delete(tempFile);
@@ -58,7 +53,6 @@ public final class JarFileResourceLoader implements ResourceLoader {
                 throw t;
             }
         }
-        jarFile = jf;
     }
 
     public Resource findResource(final String path) {

--- a/resource/src/main/java/io/smallrye/common/resource/PathResource.java
+++ b/resource/src/main/java/io/smallrye/common/resource/PathResource.java
@@ -1,5 +1,6 @@
 package io.smallrye.common.resource;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -10,6 +11,7 @@ import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -46,6 +48,23 @@ public final class PathResource extends Resource {
      */
     public Path path() {
         return path;
+    }
+
+    /**
+     * {@return {@code true} if the resource has a physical {@code File}, or {@code false} if it does not}
+     */
+    public boolean hasFile() {
+        return path.getFileSystem() == FileSystems.getDefault();
+    }
+
+    /**
+     * {@return the physical {@code File}, if there is one}
+     * Use {@link #hasFile()} to determine whether there is a physical file.
+     *
+     * @throws UnsupportedOperationException if the path does not have a physical file
+     */
+    public File file() {
+        return path.toFile();
     }
 
     public URL url() {


### PR DESCRIPTION
This simple enhancement is useful in scenarios where you need to know whether there is a physical filesystem file backing the resource; for example, native libraries or JAR files can only be opened from physical files.