### PR TITLE
Use SmallRye FFM to reliably get host name

### DIFF
--- a/net/pom.xml
+++ b/net/pom.xml
@@ -15,7 +15,16 @@
     <dependencies>
         <dependency>
             <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-annotation</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
             <artifactId>smallrye-common-constraint</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-os</artifactId>
         </dependency>
         <dependency>
             <groupId>org.graalvm.sdk</groupId>
@@ -30,6 +39,10 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.smallrye.ffm</groupId>
+            <artifactId>smallrye-ffm</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
@@ -39,6 +52,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>io.smallrye.ffm</groupId>
+                <artifactId>smallrye-ffm-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <annotationProcessorPaths>
@@ -47,6 +64,35 @@
                             <artifactId>jboss-logging-processor</artifactId>
                         </annotationProcessorPath>
                     </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <argLine>--enable-native-access=io.smallrye.ffm,io.smallrye.common.net</argLine>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/module-info.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.revelc.code</groupId>
+                <artifactId>impsort-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/module-info.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/net/src/main/java/io/smallrye/common/net/GetHostInfoAction.java
+++ b/net/src/main/java/io/smallrye/common/net/GetHostInfoAction.java
@@ -1,8 +1,19 @@
 package io.smallrye.common.net;
 
+import static io.smallrye.ffm.AsType.*;
+
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedAction;
 import java.util.regex.Pattern;
+
+import io.smallrye.common.os.OS;
+import io.smallrye.ffm.As;
+import io.smallrye.ffm.Critical;
+import io.smallrye.ffm.In;
+import io.smallrye.ffm.Lib;
+import io.smallrye.ffm.Link;
+import io.smallrye.ffm.Out;
 
 final class GetHostInfoAction implements PrivilegedAction<String[]> {
     GetHostInfoAction() {
@@ -16,6 +27,30 @@ final class GetHostInfoAction implements PrivilegedAction<String[]> {
         if (qualifiedHostName == null) {
             // if host name is specified, don't pick a qualified host name that isn't related to it
             qualifiedHostName = providedHostName;
+            if (qualifiedHostName == null && Runtime.version().feature() >= 22) {
+                switch (OS.current()) {
+                    case MAC, LINUX, AIX, Z -> {
+                        byte[] bytes = new byte[512];
+                        int res = gethostname(bytes, bytes.length);
+                        if (res == 0) {
+                            for (int i = 0; i < bytes.length; i++) {
+                                if (bytes[i] == 0) {
+                                    qualifiedHostName = new String(bytes, 0, i, StandardCharsets.UTF_8);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    case WINDOWS -> {
+                        char[] chars = new char[512];
+                        int[] lenBuf = new int[1];
+                        lenBuf[0] = chars.length;
+                        if (GetComputerNameW(chars, lenBuf)) {
+                            qualifiedHostName = new String(chars, 0, lenBuf[0]);
+                        }
+                    }
+                }
+            }
             if (qualifiedHostName == null) {
                 // POSIX-like OSes including Mac should have this set
                 qualifiedHostName = System.getenv("HOSTNAME");
@@ -57,4 +92,16 @@ final class GetHostInfoAction implements PrivilegedAction<String[]> {
                 providedNodeName
         };
     }
+
+    // POSIX
+    @Link
+    @As(stdc_int)
+    @Critical(heap = true)
+    private static native int gethostname(@Out byte[] buffer, @As(size_t) int bufLen);
+
+    // Windows
+    @Link
+    @Critical(heap = true)
+    @Lib("kernel32")
+    private static native boolean GetComputerNameW(@Out char[] buffer, @In @Out int[] lenPtr);
 }

--- a/net/src/main/java/module-info.java
+++ b/net/src/main/java/module-info.java
@@ -1,12 +1,18 @@
+import io.smallrye.common.annotation.NativeAccess;
+
 /**
  * Utilities for managing network addresses and information.
  */
+@NativeAccess
 module io.smallrye.common.net {
     requires io.smallrye.common.constraint;
     requires org.jboss.logging;
     requires static org.graalvm.nativeimage;
     requires static org.graalvm.word;
     requires static org.jboss.logging.annotations;
+    requires io.smallrye.ffm;
+    requires io.smallrye.common.os;
+    requires static io.smallrye.common.annotation;
 
     exports io.smallrye.common.net;
 }

--- a/net/src/test/java/io/smallrye/common/net/HostNameTest.java
+++ b/net/src/test/java/io/smallrye/common/net/HostNameTest.java
@@ -1,0 +1,12 @@
+package io.smallrye.common.net;
+
+import org.junit.jupiter.api.Test;
+
+public final class HostNameTest {
+    @Test
+    public void testHostName() {
+        System.out.println("Qualified name = " + HostName.getQualifiedHostName());
+        System.out.println("Host name = " + HostName.getHostName());
+        System.out.println("Node name = " + HostName.getNodeName());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <version.vertx5>5.0.10</version.vertx5>
         <version.maven-resolver>1.9.22</version.maven-resolver>
         <version.shrinkwrap>1.2.6</version.shrinkwrap>
+        <version.smallrye-ffm>0.3</version.smallrye-ffm>
         <version.org.jboss.logging>3.6.0.Final</version.org.jboss.logging>
 
         <!-- Sonar settings -->
@@ -97,6 +98,11 @@
                 <version>${version.graalvm}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>io.smallrye.ffm</groupId>
+                <artifactId>smallrye-ffm</artifactId>
+                <version>${version.smallrye-ffm}</version>
+            </dependency>
 
             <!-- External test dependencies -->
             <dependency>
@@ -114,6 +120,11 @@
             </dependency>
 
             <!-- Internal module dependencies -->
+            <dependency>
+                <groupId>io.smallrye.common</groupId>
+                <artifactId>smallrye-common-annotation</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-constraint</artifactId>
@@ -150,6 +161,19 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>io.smallrye.ffm</groupId>
+                    <artifactId>smallrye-ffm-maven-plugin</artifactId>
+                    <version>${version.smallrye-ffm}</version>
+                    <executions>
+                        <execution>
+                            <id>process-ffm</id>
+                            <goals>
+                                <goal>transform</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
                 <plugin>
                     <groupId>io.smallrye</groupId>
                     <artifactId>jandex-maven-plugin</artifactId>


### PR DESCRIPTION
This is a quick example of how SmallRye FFM can be used. In this case, we have always relied on complicated heuristics to determine the system host name because Java has no API to access this information. But with SmallRye FFM, we can just make the native call directly if the JVM allows it.

This should not necessarily be considered for merging, at least until we have solutions for both Quarkus and WildFly to register native access. But eventually, doing something like this could replace most of the heuristics that we currently employ (like probing environment variables).

Note that while this is a large change, much of the change consists of things that should be moved to a parent POM: working around impsorter bugs, establishing common versions. Also, there are some legitimately missing tests in the `net` module relating to host name (it's hard to really test in general, but we can at least make sure we don't explode).

Edit: the Windows build doesn't presently work; this may be a problem on the SmallRye FFM side, but it can be ignored for now.