### PR TITLE
Context binding overloads in ContextLocals

### DIFF
--- a/vertx5-context/src/main/java/io/smallrye/common/vertx/ContextLocals.java
+++ b/vertx5-context/src/main/java/io/smallrye/common/vertx/ContextLocals.java
@@ -50,7 +50,6 @@ public class ContextLocals {
      * @param <T> the expected type of the associated value
      * @return an optional containing the associated value if any, empty otherwise.
      */
-    @SuppressWarnings("unchecked")
     public static <T> Optional<T> get(String key) {
         return get(Vertx.currentContext(), key);
     }
@@ -87,7 +86,6 @@ public class ContextLocals {
      * @param <T> the expected type of the associated value
      * @return the associated value if any, the given default otherwise.
      */
-    @SuppressWarnings("unchecked")
     public static <T> T get(String key, T def) {
         return get(Vertx.currentContext(), key, def);
     }
@@ -247,7 +245,6 @@ public class ContextLocals {
      * @param <T> the expected type of the associated value
      * @return an optional containing the associated value if any, empty otherwise.
      */
-    @SuppressWarnings("unchecked")
     public static <T> Optional<T> getFromParent(String key) {
         return getFromParent(Vertx.currentContext(), key);
     }
@@ -290,7 +287,6 @@ public class ContextLocals {
      * @param <T> the expected type of the associated value
      * @return the associated value if any, the given default otherwise.
      */
-    @SuppressWarnings("unchecked")
     public static <T> T getFromParent(String key, T def) {
         return getFromParent(Vertx.currentContext(), key, def);
     }

--- a/vertx5-context/src/main/java/io/smallrye/common/vertx/ContextLocals.java
+++ b/vertx5-context/src/main/java/io/smallrye/common/vertx/ContextLocals.java
@@ -8,7 +8,10 @@ import io.vertx.core.Vertx;
 import io.vertx.core.internal.ContextInternal;
 
 /**
- * Utilities to access Vert.x Context locals.
+ * Utilities to access Vert.x Context locals of {@link VertxContext#DATA_MAP_LOCAL}.
+ *
+ * This facilitates the transition from Vert.x 4 by keeping a context as a {@link java.util.concurrent.ConcurrentHashMap}.
+ * It is advised to gradually embrace the new Vert.x 5 {@link io.vertx.core.spi.context.storage.ContextLocal} API.
  */
 public class ContextLocals {
 
@@ -16,14 +19,28 @@ public class ContextLocals {
         // Avoid direct instantiation
     }
 
-    private static ContextInternal ensureDuplicatedContext() {
-        Context current = Vertx.currentContext();
-        if (current == null || !VertxContext.isDuplicatedContext(current)) {
+    private static ContextInternal ensureDuplicatedContext(Context context) {
+        if (context == null || !VertxContext.isDuplicatedContext(context)) {
             throw new UnsupportedOperationException("Access to Context Locals are forbidden from a 'root' context  as " +
                     "it can leak data between unrelated processing. Make sure the method runs on a 'duplicated' (local)" +
                     " Context");
         }
-        return (ContextInternal) current;
+        return (ContextInternal) context;
+    }
+
+    /**
+     * Gets the value from the context local associated with the given key, using the given context.
+     *
+     * @param context the context, must be a duplicated context and not {@code null}
+     * @param key the key, must not be {@code null}
+     * @param <T> the expected type of the associated value
+     * @return an optional containing the associated value if any, empty otherwise.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Optional<T> get(Context context, String key) {
+        Context duplicatedContext = ensureDuplicatedContext(context);
+        var map = VertxContext.localContextData(duplicatedContext);
+        return Optional.ofNullable((T) map.get(Assert.checkNotNullParam("key", key)));
     }
 
     /**
@@ -35,9 +52,29 @@ public class ContextLocals {
      */
     @SuppressWarnings("unchecked")
     public static <T> Optional<T> get(String key) {
-        Context current = ensureDuplicatedContext();
-        var map = VertxContext.localContextData(current);
-        return Optional.ofNullable((T) map.get(Assert.checkNotNullParam("key", key)));
+        return get(Vertx.currentContext(), key);
+    }
+
+    /**
+     * Gets the value from the context local associated with the given key, using the given context.
+     * If there is no associated value, it returns the given default.
+     *
+     * @param context the context, must be a duplicated context and not {@code null}
+     * @param key the key, must not be {@code null}
+     * @param def the default value returned if there is no associated value with the given key.
+     *        Can be {@code null}
+     * @param <T> the expected type of the associated value
+     * @return the associated value if any, the given default otherwise.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T get(Context context, String key, T def) {
+        Context duplicatedContext = ensureDuplicatedContext(context);
+        var map = VertxContext.localContextData(duplicatedContext);
+        T local = (T) map.get(Assert.checkNotNullParam("key", key));
+        if (local == null) {
+            return def;
+        }
+        return local;
     }
 
     /**
@@ -52,13 +89,24 @@ public class ContextLocals {
      */
     @SuppressWarnings("unchecked")
     public static <T> T get(String key, T def) {
-        Context current = ensureDuplicatedContext();
-        var map = VertxContext.localContextData(current);
-        T local = (T) map.get(Assert.checkNotNullParam("key", key));
-        if (local == null) {
-            return def;
-        }
-        return local;
+        return get(Vertx.currentContext(), key, def);
+    }
+
+    /**
+     * Stores the given key/value in the context local of the given context.
+     * This method overwrites the existing value if any.
+     *
+     * @param context the context, must be a duplicated context and not {@code null}
+     * @param key the key, must not be {@code null}
+     * @param value the value, must not be {@code null}
+     * @param <T> the expected type of the associated value
+     */
+    public static <T> void put(Context context, String key, T value) {
+        Context duplicatedContext = ensureDuplicatedContext(context);
+        var map = VertxContext.localContextData(duplicatedContext);
+        map.put(
+                Assert.checkNotNullParam("key", key),
+                Assert.checkNotNullParam("value", value));
     }
 
     /**
@@ -70,11 +118,20 @@ public class ContextLocals {
      * @param <T> the expected type of the associated value
      */
     public static <T> void put(String key, T value) {
-        Context current = ensureDuplicatedContext();
-        var map = VertxContext.localContextData(current);
-        map.put(
-                Assert.checkNotNullParam("key", key),
-                Assert.checkNotNullParam("value", value));
+        put(Vertx.currentContext(), key, value);
+    }
+
+    /**
+     * Removes the value associated with the given key from the context locals of the given context.
+     *
+     * @param context the context, must be a duplicated context and not {@code null}
+     * @param key the key, must not be {@code null}
+     * @return {@code true} if there were a value associated with the given key. {@code false} otherwise.
+     */
+    public static boolean remove(Context context, String key) {
+        Context duplicatedContext = ensureDuplicatedContext(context);
+        var map = VertxContext.localContextData(duplicatedContext);
+        return map.remove(Assert.checkNotNullParam("key", key)) != null;
     }
 
     /**
@@ -84,9 +141,18 @@ public class ContextLocals {
      * @return {@code true} if there were a value associated with the given key. {@code false} otherwise.
      */
     public static boolean remove(String key) {
-        Context current = ensureDuplicatedContext();
-        var map = VertxContext.localContextData(current);
-        return map.remove(Assert.checkNotNullParam("key", key)) != null;
+        return remove(Vertx.currentContext(), key);
+    }
+
+    /**
+     * Gets the parent context of the given context.
+     *
+     * @param context the context, must be a duplicated context and not {@code null}
+     * @return the parent context if any, {@code null} otherwise.
+     */
+    public static Context getParentContext(Context context) {
+        var current = ensureDuplicatedContext(context);
+        return current.getLocal(VertxContext.PARENT_CONTEXT_LOCAL);
     }
 
     /**
@@ -95,8 +161,41 @@ public class ContextLocals {
      * @return the parent context if any, {@code null} otherwise.
      */
     public static Context getParentContext() {
-        var current = ensureDuplicatedContext();
-        return current.getLocal(VertxContext.PARENT_CONTEXT_LOCAL);
+        return getParentContext(Vertx.currentContext());
+    }
+
+    /**
+     * Puts the given key/value in the parent context of the given context.
+     * <p>
+     * If the parent context cannot be found, it throws an {@link IllegalStateException}.
+     * If the parent context is a root context, it throws an {@link IllegalStateException}.
+     * If the parent context is a duplicated context, the value is put in the parent context locals.
+     * <p>
+     * Values put in the parent context can only be written once, subsequent writes will be ignored.
+     * However, all the children of the parent context will have access to the value using
+     * {@link #getFromParent(Context, String)}.
+     *
+     * @param context the context, must be a duplicated context and not {@code null}
+     * @param key the key, must not be {@code null}
+     * @param value the value, must not be {@code null}
+     * @param <T> the expected type of the associated value
+     * @return {@code true} if the value was put in the parent context, {@code false} otherwise.
+     */
+    public static <T> boolean putInParent(Context context, String key, T value) {
+        var duplicatedContext = ensureDuplicatedContext(context);
+        var k = Assert.checkNotNullParam("key", key);
+        var v = Assert.checkNotNullParam("value", value);
+
+        var parent = getParentContext(duplicatedContext);
+        if (parent == null) {
+            throw new IllegalStateException("Parent context is not set");
+        }
+        if (VertxContext.isDuplicatedContext(parent)) {
+            var map = VertxContext.localContextData(parent);
+            return map.putIfAbsent(k, v) == null;
+        } else {
+            throw new IllegalStateException("The parent context is a root context");
+        }
     }
 
     /**
@@ -115,20 +214,28 @@ public class ContextLocals {
      * @return {@code true} if the value was put in the parent context, {@code false} otherwise.
      */
     public static <T> boolean putInParent(String key, T value) {
-        ensureDuplicatedContext();
-        var k = Assert.checkNotNullParam("key", key);
-        var v = Assert.checkNotNullParam("value", value);
+        return putInParent(Vertx.currentContext(), key, value);
+    }
 
-        var parent = getParentContext();
+    /**
+     * Gets the value associated with the given key from the parent of the given context.
+     * <p>
+     * If the parent context is not set, it returns an empty optional.
+     *
+     * @param context the context, must be a duplicated context and not {@code null}
+     * @param key the key, must not be {@code null}
+     * @param <T> the expected type of the associated value
+     * @return an optional containing the associated value if any, empty otherwise.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Optional<T> getFromParent(Context context, String key) {
+        var k = Assert.checkNotNullParam("key", key);
+        var parent = getParentContext(context);
         if (parent == null) {
-            throw new IllegalStateException("Parent context is not set");
+            return Optional.empty();
         }
-        if (VertxContext.isDuplicatedContext(parent)) {
-            var map = VertxContext.localContextData(parent);
-            return map.putIfAbsent(k, v) == null;
-        } else {
-            throw new IllegalStateException("The parent context is a root context");
-        }
+        var map = VertxContext.localContextData(parent);
+        return Optional.ofNullable((T) map.get(k));
     }
 
     /**
@@ -142,13 +249,34 @@ public class ContextLocals {
      */
     @SuppressWarnings("unchecked")
     public static <T> Optional<T> getFromParent(String key) {
+        return getFromParent(Vertx.currentContext(), key);
+    }
+
+    /**
+     * Gets the value associated with the given key from the parent of the given context.
+     * <p>
+     * If the parent context is not set, it returns the given default.
+     * If there is a parent context, but, there is no associated value with the given key, it returns the given default.
+     *
+     * @param context the context, must be a duplicated context and not {@code null}
+     * @param key the key, must not be {@code null}
+     * @param def the default value returned if there is no associated value with the given key.
+     * @param <T> the expected type of the associated value
+     * @return the associated value if any, the given default otherwise.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T getFromParent(Context context, String key, T def) {
         var k = Assert.checkNotNullParam("key", key);
-        var parent = getParentContext();
+        var parent = getParentContext(context);
         if (parent == null) {
-            return Optional.empty();
+            return def;
         }
         var map = VertxContext.localContextData(parent);
-        return Optional.ofNullable((T) map.get(k));
+        T local = (T) map.get(k);
+        if (local == null) {
+            return def;
+        }
+        return local;
     }
 
     /**
@@ -164,16 +292,6 @@ public class ContextLocals {
      */
     @SuppressWarnings("unchecked")
     public static <T> T getFromParent(String key, T def) {
-        var k = Assert.checkNotNullParam("key", key);
-        var parent = getParentContext();
-        if (parent == null) {
-            return def;
-        }
-        var map = VertxContext.localContextData(parent);
-        T local = (T) map.get(k);
-        if (local == null) {
-            return def;
-        }
-        return local;
+        return getFromParent(Vertx.currentContext(), key, def);
     }
 }

--- a/vertx5-context/src/test/java/io/smallrye/common/vertx/ContextLocalsNestedContextTest.java
+++ b/vertx5-context/src/test/java/io/smallrye/common/vertx/ContextLocalsNestedContextTest.java
@@ -99,6 +99,23 @@ class ContextLocalsNestedContextTest {
 
     @Test
     @Timeout(value = 2000)
+    void testGetParentContextWithExplicitContext(Vertx vertx, VertxTestContext testContext) {
+        vertx.runOnContext(v -> {
+            Context base = VertxContext.getOrCreateDuplicatedContext(vertx);
+            base.runOnContext(r -> {
+                Context nested = VertxContext.newNestedContext(base);
+                nested.runOnContext(n -> {
+                    Context parent = ContextLocals.getParentContext(nested);
+                    assertThat(parent).isNotNull();
+                    assertThat(parent).isSameAs(base);
+                    testContext.completeNow();
+                });
+            });
+        });
+    }
+
+    @Test
+    @Timeout(value = 2000)
     void testGetFromParentWithDefault(Vertx vertx, VertxTestContext testContext) {
         vertx.runOnContext(v -> {
             Context parent = VertxContext.getOrCreateDuplicatedContext(vertx);
@@ -208,6 +225,66 @@ class ContextLocalsNestedContextTest {
                     assertThat(ContextLocals.getFromParent("key")).isEmpty();
                     testContext.completeNow();
                 });
+            });
+        });
+    }
+
+    @Test
+    @Timeout(value = 2000)
+    void testPutInParentWithExplicitContext(Vertx vertx, VertxTestContext testContext) {
+        vertx.runOnContext(v -> {
+            Context parent = VertxContext.getOrCreateDuplicatedContext(vertx);
+            parent.runOnContext(p -> {
+                Context nested = VertxContext.newNestedContext(parent);
+                nested.runOnContext(n -> {
+                    boolean result = ContextLocals.putInParent(nested, "key", "value");
+                    assertThat(result).isTrue();
+
+                    // Verify via parent context directly
+                    var parentCtx = ContextLocals.getParentContext(nested);
+                    var map = VertxContext.localContextData(parentCtx);
+                    assertThat(map.get("key")).isEqualTo("value");
+
+                    boolean secondResult = ContextLocals.putInParent(nested, "key", "override");
+                    assertThat(secondResult).isFalse();
+
+                    testContext.completeNow();
+                });
+            });
+        });
+    }
+
+    @Test
+    @Timeout(value = 2000)
+    void testGetFromParentWithExplicitContext(Vertx vertx, VertxTestContext testContext) {
+        vertx.runOnContext(v -> {
+            Context parent = VertxContext.getOrCreateDuplicatedContext(vertx);
+            parent.runOnContext(p -> {
+                ContextLocals.put("key", "parentValue");
+
+                Context nested = VertxContext.newNestedContext(parent);
+                nested.runOnContext(n -> {
+                    assertThat(ContextLocals.getFromParent(nested, "key")).hasValue("parentValue");
+                    assertThat(ContextLocals.getFromParent(nested, "missing")).isEmpty();
+
+                    assertThat(ContextLocals.getFromParent(nested, "key", "default")).isEqualTo("parentValue");
+                    assertThat(ContextLocals.getFromParent(nested, "missing", "default")).isEqualTo("default");
+
+                    testContext.completeNow();
+                });
+            });
+        });
+    }
+
+    @Test
+    @Timeout(value = 2000)
+    void testGetFromParentWithExplicitContextNoParent(Vertx vertx, VertxTestContext testContext) {
+        vertx.runOnContext(v -> {
+            Context dup = VertxContext.getOrCreateDuplicatedContext(vertx);
+            dup.runOnContext(d -> {
+                assertThat(ContextLocals.getFromParent(dup, "key")).isEmpty();
+                assertThat(ContextLocals.getFromParent(dup, "key", "default")).isEqualTo("default");
+                testContext.completeNow();
             });
         });
     }

--- a/vertx5-context/src/test/java/io/smallrye/common/vertx/ContextLocalsTest.java
+++ b/vertx5-context/src/test/java/io/smallrye/common/vertx/ContextLocalsTest.java
@@ -95,4 +95,74 @@ public class ContextLocalsTest {
             });
         });
     }
+
+    @Test
+    public void assertGetWithExplicitContext(Vertx vertx, VertxTestContext tc) {
+        Checkpoint checkpoint = tc.checkpoint(1);
+
+        Context root = vertx.getOrCreateContext();
+        Context dup = VertxContext.getOrCreateDuplicatedContext(root);
+
+        dup.runOnContext(x -> {
+            Assertions.assertThat(ContextLocals.get(dup, "foo")).isEmpty();
+            ContextLocals.put("foo", "bar");
+            Assertions.assertThat(ContextLocals.get(dup, "foo")).contains("bar");
+            Assertions.assertThat(ContextLocals.get(dup, "missing")).isEmpty();
+            Assertions.assertThat(ContextLocals.get(dup, "foo", "default")).isEqualTo("bar");
+            Assertions.assertThat(ContextLocals.get(dup, "missing", 42)).isEqualTo(42);
+            checkpoint.flag();
+        });
+    }
+
+    @Test
+    public void assertGetWithExplicitContextRejectsRootContext(Vertx vertx, VertxTestContext tc) {
+        Checkpoint checkpoint = tc.checkpoint(1);
+
+        vertx.runOnContext(x -> {
+            Context root = Vertx.currentContext();
+            Assertions.assertThatThrownBy(() -> ContextLocals.get(root, "foo"))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            Assertions.assertThatThrownBy(() -> ContextLocals.get(root, "foo", "def"))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            checkpoint.flag();
+        });
+    }
+
+    @Test
+    public void assertGetWithNullContextFails() {
+        Assertions.assertThatThrownBy(() -> ContextLocals.get((Context) null, "foo"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void assertPutAndRemoveWithExplicitContext(Vertx vertx, VertxTestContext tc) {
+        Checkpoint checkpoint = tc.checkpoint(1);
+
+        Context root = vertx.getOrCreateContext();
+        Context dup = VertxContext.getOrCreateDuplicatedContext(root);
+
+        dup.runOnContext(x -> {
+            ContextLocals.put(dup, "foo", "bar");
+            Assertions.assertThat(ContextLocals.get(dup, "foo")).contains("bar");
+
+            Assertions.assertThat(ContextLocals.remove(dup, "foo")).isTrue();
+            Assertions.assertThat(ContextLocals.get(dup, "foo")).isEmpty();
+            Assertions.assertThat(ContextLocals.remove(dup, "foo")).isFalse();
+            checkpoint.flag();
+        });
+    }
+
+    @Test
+    public void assertPutWithExplicitContextRejectsRootContext(Vertx vertx, VertxTestContext tc) {
+        Checkpoint checkpoint = tc.checkpoint(1);
+
+        vertx.runOnContext(x -> {
+            Context root = Vertx.currentContext();
+            Assertions.assertThatThrownBy(() -> ContextLocals.put(root, "foo", "bar"))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            Assertions.assertThatThrownBy(() -> ContextLocals.remove(root, "foo"))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            checkpoint.flag();
+        });
+    }
 }


### PR DESCRIPTION
This facilitates usages of the API where we get the current context before we try to access the data.