### PR TITLE
Fix three bugs in BufferedFile

### DIFF
--- a/io/src/main/java/io/smallrye/common/io/BufferedFile.java
+++ b/io/src/main/java/io/smallrye/common/io/BufferedFile.java
@@ -276,12 +276,12 @@ public final class BufferedFile implements Closeable, Flushable {
                 flushDirty();
                 raf.seek(position);
                 bufferPosition = position;
-                int n = raf.read(buffer, bufferDataSize, buffer.length - bufferDataSize);
+                bufferDataSize = 0;
+                int n = raf.read(buffer, 0, buffer.length);
                 if (n == -1) {
-                    bufferDataSize = 0;
                     return -1;
                 }
-                bufferDataSize += n;
+                bufferDataSize = n;
                 return n;
             }
             // the current position is inside the buffer
@@ -3783,7 +3783,7 @@ public final class BufferedFile implements Closeable, Flushable {
 
         @Override
         public int readUnsignedByte() throws IOException {
-            return BufferedFile.this.readByte();
+            return BufferedFile.this.readUnsignedByte();
         }
 
         @Override
@@ -3793,7 +3793,7 @@ public final class BufferedFile implements Closeable, Flushable {
 
         @Override
         public int readUnsignedShort() throws IOException {
-            return BufferedFile.this.readShortBE();
+            return BufferedFile.this.readUnsignedShortBE();
         }
 
         @Override

--- a/io/src/test/java/io/smallrye/common/io/BufferedFileTest.java
+++ b/io/src/test/java/io/smallrye/common/io/BufferedFileTest.java
@@ -2960,6 +2960,73 @@ class BufferedFileTest {
         }
     }
 
+    // ── Bug regression tests ─────────────────────────────────────────────
+
+    /**
+     * Verify that seeking outside the buffer window and reading
+     * returns fresh data, not stale bytes left over from the old buffer.
+     */
+    @Test
+    void fillAfterSeekOutsideBufferReturnsCorrectData() throws IOException {
+        Path f = testFile();
+        try (Closeable ignored = tempFile(f)) {
+            // create a file with 256 known bytes: 0x00..0xFF
+            byte[] data = new byte[256];
+            for (int i = 0; i < data.length; i++) {
+                data[i] = (byte) i;
+            }
+            Files.write(f, data);
+            // use a small buffer (32 bytes) so we can easily seek outside it
+            try (BufferedFile bf = Files2.openBuffered(f, READ, BufferSizeOption.of(32))) {
+                // fill the buffer from position 0 — loads bytes 0x00..0x1F
+                bf.fill(1);
+                assertEquals(0x00, bf.readUnsignedByte());
+                assertEquals(0x01, bf.readUnsignedByte());
+                // seek far outside the current buffer window
+                bf.seek(128);
+                // read — this should return 0x80, not stale buffer[0] = 0x00
+                assertEquals(0x80, bf.readUnsignedByte());
+                assertEquals(0x81, bf.readUnsignedByte());
+            }
+        }
+    }
+
+    /**
+     * Verify that {@code BufferedFileInputStream.readUnsignedByte()}
+     * returns unsigned values (0–255) for bytes with the high bit set.
+     */
+    @Test
+    void inputStreamReadUnsignedByteReturnsUnsigned() throws IOException {
+        Path f = testFile();
+        try (Closeable ignored = tempFile(f)) {
+            Files.write(f, new byte[] { (byte) 0xFF, (byte) 0x80, 0x7F });
+            try (BufferedFile bf = Files2.openBuffered(f, READ)) {
+                DataInput in = bf.inputStream();
+                assertEquals(255, in.readUnsignedByte());
+                assertEquals(128, in.readUnsignedByte());
+                assertEquals(127, in.readUnsignedByte());
+            }
+        }
+    }
+
+    /**
+     * Verify that {@code BufferedFileInputStream.readUnsignedShort()}
+     * returns unsigned values (0–65535) for shorts with the high bit set.
+     */
+    @Test
+    void inputStreamReadUnsignedShortReturnsUnsigned() throws IOException {
+        Path f = testFile();
+        try (Closeable ignored = tempFile(f)) {
+            // 0xFF 0xFF = unsigned 65535, 0x80 0x00 = unsigned 32768
+            Files.write(f, new byte[] { (byte) 0xFF, (byte) 0xFF, (byte) 0x80, 0x00 });
+            try (BufferedFile bf = Files2.openBuffered(f, READ)) {
+                DataInput in = bf.inputStream();
+                assertEquals(65535, in.readUnsignedShort());
+                assertEquals(32768, in.readUnsignedShort());
+            }
+        }
+    }
+
     // test utilities
 
     Closeable tempFile(Path path) {


### PR DESCRIPTION
- Reading bytes and unsigned shorts were not properly zero-extended
- A possible bug around reading uninitialized data from the buffer in certain circumstances