### PR TITLE
Deprecate JAR utilities

### DIFF
--- a/io/src/main/java/io/smallrye/common/io/jar/JarEntries.java
+++ b/io/src/main/java/io/smallrye/common/io/jar/JarEntries.java
@@ -5,6 +5,7 @@ import java.util.jar.JarEntry;
 /**
  * Utility class for handling JAR entries.
  */
+@Deprecated(since = "2.19", forRemoval = true)
 public class JarEntries {
     private JarEntries() {
     }

--- a/io/src/main/java/io/smallrye/common/io/jar/JarFiles.java
+++ b/io/src/main/java/io/smallrye/common/io/jar/JarFiles.java
@@ -8,6 +8,7 @@ import java.util.zip.ZipFile;
 /**
  * Java 9+ variant of a JDK-specific class for working with {@code JarFile}s.
  */
+@Deprecated(since = "2.19", forRemoval = true)
 public class JarFiles {
     private JarFiles() {
     }


### PR DESCRIPTION
These were only useful when the library could run on Java 8.