### PR TITLE
Support memory-mapped resources

### DIFF
--- a/resource/src/main/java/io/smallrye/common/resource/MemoryResource.java
+++ b/resource/src/main/java/io/smallrye/common/resource/MemoryResource.java
@@ -73,6 +73,19 @@ public final class MemoryResource extends Resource {
         return data.duplicate();
     }
 
+    public boolean isMappable() {
+        return true;
+    }
+
+    public ByteBuffer mapAsBuffer(final long offset, final int length) {
+        Assert.checkMinimumParameter("offset", 0, offset);
+        Assert.checkMinimumParameter("length", 0, length);
+        int lim = data.limit();
+        Assert.checkMaximumParameter("offset", lim, offset);
+        Assert.checkMaximumParameter("length", lim - offset, length);
+        return data.slice((int) offset, length);
+    }
+
     public long copyTo(final Path destination) throws IOException {
         try (SeekableByteChannel ch = Files.newByteChannel(destination, StandardOpenOption.CREATE,
                 StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {

--- a/resource/src/main/java/io/smallrye/common/resource/PathResource.java
+++ b/resource/src/main/java/io/smallrye/common/resource/PathResource.java
@@ -123,6 +123,16 @@ public final class PathResource extends Resource {
         }
     }
 
+    public boolean isMappable() {
+        return Files.isRegularFile(path());
+    }
+
+    public MappedByteBuffer mapAsBuffer(final long offset, final int length) throws IOException {
+        try (FileChannel fc = FileChannel.open(path(), StandardOpenOption.READ)) {
+            return fc.map(FileChannel.MapMode.READ_ONLY, offset, length);
+        }
+    }
+
     public String asString(final Charset charset) throws IOException {
         return Files.readString(path(), charset);
     }

--- a/resource/src/main/java/io/smallrye/common/resource/Resource.java
+++ b/resource/src/main/java/io/smallrye/common/resource/Resource.java
@@ -121,6 +121,56 @@ public abstract class Resource {
     }
 
     /**
+     * {@return {@code true} if this resource can be mapped into memory, or {@code false} if it cannot be}
+     */
+    public boolean isMappable() {
+        return false;
+    }
+
+    /**
+     * {@return the mapped view of this resource as a buffer}
+     * If the resource is not mappable, an exception is thrown;
+     * use {@link #isMappable()} to determine whether mapping this resource can succeed.
+     * It is unspecified whether mapping past the end of the file is supported;
+     * an exception may be thrown in this case.
+     * <p>
+     * If this method succeeds, the returned buffer is a read-only memory-mapped
+     * view of the resource data.
+     * Depending on the OS implementation, updates to the backing file
+     * may or may not cause the mapped view to be updated at the same time.
+     *
+     * @param offset the offset into the resource to map
+     * @param length the number of bytes to map
+     * @throws IOException if there is a mapping error, or if the resource is not mappable
+     * @throws IllegalArgumentException if the offset or length is negative
+     */
+    public ByteBuffer mapAsBuffer(long offset, int length) throws IOException {
+        throw new IOException("Not a mappable resource");
+    }
+
+    /**
+     * {@return the mapped view of this resource as a buffer}
+     * If the resource is not mappable, an exception is thrown;
+     * use {@link #isMappable()} to determine whether mapping this resource can succeed.
+     * It is unspecified whether mapping past the end of the file is supported;
+     * an exception may be thrown in this case.
+     * <p>
+     * If this method succeeds, the returned buffer is a read-only memory-mapped
+     * view of the resource data.
+     * Depending on the OS implementation, updates to the backing file
+     * may or may not cause the mapped view to be updated at the same time.
+     *
+     * @throws IOException if there is a mapping error, or if the resource is not mappable
+     */
+    public ByteBuffer mapAsBuffer() throws IOException {
+        long size = size();
+        if (size > Integer.MAX_VALUE - 16) {
+            throw new IllegalArgumentException("Resource is too large to map as a single buffer");
+        }
+        return mapAsBuffer(0, (int) size);
+    }
+
+    /**
      * Copy the bytes of this resource to the given destination.
      * The copy may fail before all of the bytes have been transferred;
      * in this case the content and state of the destination are undefined.


### PR DESCRIPTION
This supports the upcoming archive nesting feature.

This differs from `asBuffer()`. That method unconditionally reads the entire resource into a buffer, possibly (but not necessarily) using memory mapping; the intended use of that method is class definition, where a complete buffer must always be present.

`mapAsBuffer()`, on the other hand, _always_ maps the resource, failing if it cannot be mapped (the companion `isMappable()` method is useful for this case).