### PR TITLE
Add beginDispatch/endDispatch to VertxContext

### DIFF
--- a/vertx4-context/src/main/java/io/smallrye/common/vertx/VertxContext.java
+++ b/vertx4-context/src/main/java/io/smallrye/common/vertx/VertxContext.java
@@ -277,4 +277,54 @@ public class VertxContext {
         return newNestedContext(Vertx.currentContext());
     }
 
+    /**
+     * Begins the execution of a task on the given context.
+     * <p>
+     * This method makes the given context the current thread-local context, so that subsequent calls to
+     * {@link Vertx#currentContext()} return this context. It returns the previous context (if any), which
+     * <strong>must</strong> be passed to {@link #endDispatch(Context, Context)} when the task is complete.
+     * </p>
+     * <p>
+     * This is a low-level API intended for situations where the begin and end of a dispatch cannot be wrapped
+     * in a single {@code Runnable} (e.g., JCA message endpoint delivery where {@code beforeDelivery} and
+     * {@code afterDelivery} are separate calls). Prefer the Vert.x {@code Context#dispatch} methods when possible.
+     * </p>
+     *
+     * @param context the context to begin dispatching on, must not be {@code null}
+     * @return the previous context that was active on this thread, or {@code null} if there was none
+     * @see #endDispatch(Context, Context)
+     */
+    public static @Nullable Context beginDispatch(Context context) {
+        ContextInternal actual = Assert.checkNotNullParam("context", (ContextInternal) context);
+        return actual.beginDispatch();
+    }
+
+    /**
+     * Ends the execution of a task on the given context, restoring the previous context.
+     * <p>
+     * This method restores the thread-local context to the {@code previous} context that was returned by
+     * {@link #beginDispatch(Context)}. It must be called in a {@code finally} block to ensure proper cleanup.
+     * </p>
+     * <p>
+     * Typical usage:
+     * </p>
+     *
+     * <pre>
+     * Context previous = VertxContext.beginDispatch(myContext);
+     * try {
+     *     // ... perform work on myContext ...
+     * } finally {
+     *     VertxContext.endDispatch(myContext, previous);
+     * }
+     * </pre>
+     *
+     * @param context the context on which {@link #beginDispatch(Context)} was called, must not be {@code null}
+     * @param previous the previous context returned by {@link #beginDispatch(Context)}, or {@code null} if there was none
+     * @see #beginDispatch(Context)
+     */
+    public static void endDispatch(Context context, @Nullable Context previous) {
+        ContextInternal actual = Assert.checkNotNullParam("context", (ContextInternal) context);
+        actual.endDispatch((ContextInternal) previous);
+    }
+
 }

--- a/vertx4-context/src/test/java/io/smallrye/common/vertx/VertxContextTest.java
+++ b/vertx4-context/src/test/java/io/smallrye/common/vertx/VertxContextTest.java
@@ -180,6 +180,28 @@ public class VertxContextTest {
     }
 
     @Test
+    void testBeginAndEndDispatch(Vertx vertx, VertxTestContext tc) {
+        var root = vertx.getOrCreateContext();
+        root.runOnContext(ignored -> {
+            var originalContext = Vertx.currentContext();
+            assertThat(originalContext).isNotNull();
+
+            var duplicated = VertxContext.createNewDuplicatedContext(root);
+            assertThat(duplicated).isNotNull();
+
+            Context previous = VertxContext.beginDispatch(duplicated);
+            try {
+                assertThat(Vertx.currentContext()).isSameAs(duplicated);
+                assertThat(previous).isSameAs(originalContext);
+            } finally {
+                VertxContext.endDispatch(duplicated, previous);
+            }
+            assertThat(Vertx.currentContext()).isSameAs(originalContext);
+            tc.completeNow();
+        });
+    }
+
+    @Test
     void testDuplicationOfDuplicateUsingVertxAPI(Vertx vertx, VertxTestContext tc) {
         var root = vertx.getOrCreateContext();
         assertThat(VertxContext.isDuplicatedContext(root)).isFalse();

--- a/vertx5-context/src/main/java/io/smallrye/common/vertx/VertxContext.java
+++ b/vertx5-context/src/main/java/io/smallrye/common/vertx/VertxContext.java
@@ -311,4 +311,55 @@ public class VertxContext {
     public static Context newNestedContext() {
         return newNestedContext(Vertx.currentContext());
     }
+
+    /**
+     * Begins the execution of a task on the given context.
+     * <p>
+     * This method makes the given context the current thread-local context, so that subsequent calls to
+     * {@link Vertx#currentContext()} return this context. It returns the previous context (if any), which
+     * <strong>must</strong> be passed to {@link #endDispatch(Context, Context)} when the task is complete.
+     * </p>
+     * <p>
+     * This is a low-level API intended for situations where the begin and end of a dispatch cannot be wrapped
+     * in a single {@code Runnable} (e.g., JCA message endpoint delivery where {@code beforeDelivery} and
+     * {@code afterDelivery} are separate calls). Prefer the Vert.x {@code Context#dispatch} methods when possible.
+     * </p>
+     *
+     * @param context the context to begin dispatching on, must not be {@code null}
+     * @return the previous context that was active on this thread, or {@code null} if there was none
+     * @see #endDispatch(Context, Context)
+     */
+    public static @Nullable Context beginDispatch(Context context) {
+        ContextInternal actual = Assert.checkNotNullParam("context", (ContextInternal) context);
+        return actual.beginDispatch();
+    }
+
+    /**
+     * Ends the execution of a task on the given context, restoring the previous context.
+     * <p>
+     * This method restores the thread-local context to the {@code previous} context that was returned by
+     * {@link #beginDispatch(Context)}. It must be called in a {@code finally} block to ensure proper cleanup.
+     * </p>
+     * <p>
+     * Typical usage:
+     * </p>
+     *
+     * <pre>
+     * Context previous = VertxContext.beginDispatch(myContext);
+     * try {
+     *     // ... perform work on myContext ...
+     * } finally {
+     *     VertxContext.endDispatch(myContext, previous);
+     * }
+     * </pre>
+     *
+     * @param context the context on which {@link #beginDispatch(Context)} was called, must not be {@code null}
+     * @param previous the previous context returned by {@link #beginDispatch(Context)}, or {@code null} if there was none
+     * @see #beginDispatch(Context)
+     */
+    public static void endDispatch(Context context, @Nullable Context previous) {
+        ContextInternal actual = Assert.checkNotNullParam("context", (ContextInternal) context);
+        actual.endDispatch((ContextInternal) previous);
+    }
+
 }

--- a/vertx5-context/src/test/java/io/smallrye/common/vertx/VertxContextTest.java
+++ b/vertx5-context/src/test/java/io/smallrye/common/vertx/VertxContextTest.java
@@ -180,6 +180,28 @@ public class VertxContextTest {
     }
 
     @Test
+    void testBeginAndEndDispatch(Vertx vertx, VertxTestContext tc) {
+        var root = vertx.getOrCreateContext();
+        root.runOnContext(ignored -> {
+            var originalContext = Vertx.currentContext();
+            assertThat(originalContext).isNotNull();
+
+            var duplicated = VertxContext.createNewDuplicatedContext(root);
+            assertThat(duplicated).isNotNull();
+
+            Context previous = VertxContext.beginDispatch(duplicated);
+            try {
+                assertThat(Vertx.currentContext()).isSameAs(duplicated);
+                assertThat(previous).isSameAs(originalContext);
+            } finally {
+                VertxContext.endDispatch(duplicated, previous);
+            }
+            assertThat(Vertx.currentContext()).isSameAs(originalContext);
+            tc.completeNow();
+        });
+    }
+
+    @Test
     void testDuplicationOfDuplicateUsingVertxAPI(Vertx vertx, VertxTestContext tc) {
         var root = vertx.getOrCreateContext();
         assertThat(VertxContext.isDuplicatedContext(root)).isFalse();


### PR DESCRIPTION
## Summary

- Add `VertxContext.beginDispatch(Context)` and `VertxContext.endDispatch(Context, Context)` static methods to both `vertx4-context` and `vertx5-context` modules
- These methods wrap `ContextInternal.beginDispatch()` / `endDispatch()` so that consumers can manage the thread-local context dispatch lifecycle without depending on the Vert.x internal API

## Motivation

The whole point of `VertxContext` is to shield consumers from `ContextInternal` — but until now it only covered context *creation* (duplicate, nested, etc.), not context *dispatch*. This forced projects like [quarkus-ironjacamar](https://github.com/quarkiverse/quarkus-ironjacamar) to import `ContextInternal` directly for `beginDispatch()` / `endDispatch()` calls (see [`DuplicatedContextMessageEndpoint`](https://github.com/quarkiverse/quarkus-ironjacamar/blob/main/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/DuplicatedContextMessageEndpoint.java)).

The JCA message endpoint delivery lifecycle splits begin/end across separate method calls (`beforeDelivery` → message delivery → `afterDelivery`), so the higher-level `Context.dispatch(Runnable)` API cannot be used. These new methods fill that gap.

## Test plan

- [x] Added `testBeginAndEndDispatch` to both `vertx4-context` and `vertx5-context` test suites
- [x] Tests verify that `beginDispatch` sets the thread-local context and returns the previous one, and `endDispatch` restores it
- [x] `mvn test -pl vertx4-context,vertx5-context` passes