### PR TITLE
Expression PRESERVE_UNKNOWN_ESCAPES flag

### DIFF
--- a/expression/src/main/java/io/smallrye/common/expression/Expression.java
+++ b/expression/src/main/java/io/smallrye/common/expression/Expression.java
@@ -609,6 +609,11 @@ public final class Expression {
                                     break;
                                 }
                                 default: {
+                                    if (flags.contains(Flag.PRESERVE_UNKNOWN_ESCAPES)) {
+                                        // keep the backslash and the following character verbatim, e.g. "\," -> "\,".
+                                        // 'start' still points at the backslash, so just keep accumulating.
+                                        continue;
+                                    }
                                     if (flags.contains(Flag.LENIENT_SYNTAX)) {
                                         // TP 40
                                         // just append the literal character after the \, whatever it was
@@ -712,5 +717,10 @@ public final class Expression {
          * Treat expressions containing a double-colon delimiter as special, encoding the entire content into the key.
          */
         DOUBLE_COLON,
+        /**
+         * When combined with {@link #ESCAPES}, preserve unrecognized escape sequences verbatim, including the leading
+         * backslash. Has no effect unless {@link #ESCAPES} is also set.
+         */
+        PRESERVE_UNKNOWN_ESCAPES,
     }
 }

--- a/expression/src/test/java/io/smallrye/common/expression/ExpressionTestCase.java
+++ b/expression/src/test/java/io/smallrye/common/expression/ExpressionTestCase.java
@@ -809,4 +809,30 @@ public class ExpressionTestCase {
             assertEquals("bar", c.getKey());
         }));
     }
+
+    @Test
+    void preserveUnknownEscapes() {
+        assertEquals("a\\,b", Expression.compile("a\\,b", ESCAPES, PRESERVE_UNKNOWN_ESCAPES).evaluate((c, b) -> {
+        }));
+        assertEquals("sea\\,turtle", Expression.compile("sea\\,turtle", ESCAPES, PRESERVE_UNKNOWN_ESCAPES).evaluate((c, b) -> {
+        }));
+        assertEquals("\\.\\{", Expression.compile("\\.\\{", ESCAPES, PRESERVE_UNKNOWN_ESCAPES).evaluate((c, b) -> {
+        }));
+
+        assertEquals("$", Expression.compile("\\$", ESCAPES, PRESERVE_UNKNOWN_ESCAPES).evaluate((c, b) -> {
+        }));
+        assertEquals("${foo}", Expression.compile("\\${foo}", ESCAPES, PRESERVE_UNKNOWN_ESCAPES).evaluate((c, b) -> {
+        }));
+        assertEquals("\\", Expression.compile("\\\\", ESCAPES, PRESERVE_UNKNOWN_ESCAPES).evaluate((c, b) -> {
+        }));
+        assertEquals("\n", Expression.compile("\\n", ESCAPES, PRESERVE_UNKNOWN_ESCAPES).evaluate((c, b) -> {
+        }));
+
+        assertEquals("x\\,y", Expression.compile("${foo}\\,y", ESCAPES, PRESERVE_UNKNOWN_ESCAPES).evaluate((c, b) -> {
+            b.append("x");
+        }));
+
+        assertEquals("a\\", Expression.compile("a\\", ESCAPES, PRESERVE_UNKNOWN_ESCAPES, LENIENT_SYNTAX).evaluate((c, b) -> {
+        }));
+    }
 }


### PR DESCRIPTION
Adds `Expression.Flag.PRESERVE_UNKNOWN_ESCAPES`. 

When combined with `ESCAPES`, an unrecognized escape (e.g. `\,`) is emitted verbatim with its leading backslash, instead of dropping the backslash (`LENIENT_SYNTAX`) or throwing. Recognized escapes (`\\`, `\$`, `\n`, `\r`, `\t`, `\b`, `\f`) are unaffected, and the flag is a no-op unless `ESCAPES` is set.

This would allow us to support the comma escape in values that represent arrays:
https://github.com/smallrye/smallrye-common/pull/344#issuecomment-2356616925

In `SmallRyeConfig`, we would then enable `NO_$$`, `ESCAPES` and `PRESERVE_UNKNOWN_ESCAPES` to fix:
- https://github.com/smallrye/smallrye-config/issues/1219
- https://github.com/smallrye/smallrye-config/issues/746
- https://github.com/smallrye/smallrye-config/issues/1056
- https://github.com/quarkusio/quarkus/issues/41883

The only breaking change would be that `$$` no longer acts as an escape for expressions.
